### PR TITLE
[wip] Setup TravisCI or CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: haskell:8.2
+        environment:
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - stack-dhall-v1.15.1
+      - run:
+          name: Install dependencies
+          command: |
+            apt-get -qq update
+            apt-get -qqy install netbase python3
+            stack upgrade
+            export PATH=~/.local/bin:$PATH
+            stack --skip-ghc-check --system-ghc install dhall-1.15.1
+      - save_cache:
+          key: stack-dhall-v1.15.1
+          paths: [ ~/.stack ]
+          when: always
+      - run:
+          name: Test
+          command: |
+            python3 check-source.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sude: false
+
+language: haskell
+
+ghc:
+  - 8.2
+
+addons:
+  apt:
+    update: true
+    packages:
+      - python3
+
+cache:
+  directories:
+    - $HOME/.stack
+
+install:
+  - mkdir -p ~/.local/bin
+  - export PATH=~/.local/bin:$PATH
+  - travis_retry curl -sSL https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - stack --skip-ghc-check --system-ghc install dhall-1.15.1
+
+script:
+  - python3 check-source.py

--- a/check-source.py
+++ b/check-source.py
@@ -29,8 +29,8 @@ for default_file in default_files:
         print('Skipping {}'.format(default_file))
         continue
     print('Checking {}'.format(default_file))
-    cmd = 'dhall resolve <<< {file}'.format(file=default_file)
-    result = run(cmd, shell=True, stdout=DEVNULL, stderr=PIPE)
+    cmd = ['/bin/bash', '-c', 'cat <<< {file}'.format(file=default_file)]
+    result = run(cmd, shell=False, stdout=DEVNULL, stderr=PIPE)
     if result.returncode != 0:
         print(result.stderr.decode('utf-8'))
         failure_files.add(default_file)


### PR DESCRIPTION
This PR includes the setup for both CircleCI and TravisCI to run `check-sources.py`.

TravisCI does not work because of a wrong python version and it is markedly slower

<table>
<tr>
<th></th>
<th>Uncached</th>
<th>Cached</th>
</tr>
<tr>
<th>Travis</th>
<td><a href="https://travis-ci.org/geigerzaehler/dhall-kubernetes/builds/401498664">30min</a></td>
<td><a href="https://travis-ci.org/geigerzaehler/dhall-kubernetes/builds/401506484">6min</a></td>
</tr>
<tr>
<th>Circle</th>
<td><a href="https://circleci.com/gh/geigerzaehler/dhall-kubernetes/3">14min</a></td>
<td><a href="https://circleci.com/gh/geigerzaehler/dhall-kubernetes/4">1min</a></td>
</tr>
</table>

I’d go with just CircleCI