### PR TITLE
Fix $ in record labels: start emitting quoted ones

### DIFF
--- a/check-source.py
+++ b/check-source.py
@@ -12,6 +12,14 @@ from subprocess import run, DEVNULL, PIPE
 
 # We skip tests for the following set of files
 ignored_failures = {
+    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec.dhall',
+    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation.dhall',
+    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps.dhall',
+    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition.dhall',
+    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionList.dhall',
+    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray.dhall',
+    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool.dhall',
+    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray.dhall',
 }
 
 default_files = glob('./default/*.dhall')

--- a/check-source.py
+++ b/check-source.py
@@ -12,14 +12,6 @@ from subprocess import run, DEVNULL, PIPE
 
 # We skip tests for the following set of files
 ignored_failures = {
-    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec.dhall',
-    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation.dhall',
-    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps.dhall',
-    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition.dhall',
-    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionList.dhall',
-    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray.dhall',
-    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool.dhall',
-    './default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray.dhall',
 }
 
 default_files = glob('./default/*.dhall')

--- a/convert.py
+++ b/convert.py
@@ -85,7 +85,7 @@ def labelize(propName):
     If a propName doesn't match the 'simple-label' grammar, we return a quoted label
     See: https://github.com/dhall-lang/dhall-lang/blob/1d2912067658fdbbc17696fc86f057d6f91712b9/standard/dhall.abnf#L125
     """
-    if not re.match("^[a-zA-Z_][\w\-/]*$", propName):
+    if not re.match("^[a-zA-Z_][a-zA-Z0-9_\-/]*$", propName):
         return "`" + propName + "`"
     else:
         return propName

--- a/convert.py
+++ b/convert.py
@@ -79,6 +79,16 @@ def get_static_data(modelSpec):
         return {}
 
 
+def labelize(propName):
+    """
+    If a propName contains a `$`, we have to return a quoted label
+    """
+    if "$" in propName:
+        return "`" + propName + "`"
+    else:
+        return propName
+
+
 url = 'https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json'
 
 # See https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
@@ -105,7 +115,7 @@ def main():
 
                 properties = modelSpec.get('properties', {})
 
-                fields = [" {} : ({})\n".format(propName, get_typ(propVal, propName in required))
+                fields = [" {} : ({})\n".format(labelize(propName), get_typ(propVal, propName in required))
                           for propName, propVal in properties.items()]
                 f.write('{' + ','.join(fields) + '}\n')
 
@@ -124,7 +134,7 @@ def main():
 
                 # If there's any required props, we make it a lambda
                 if len([k for k in properties if k in required]) > 0:
-                    params = ['{} : ({})'.format(propName, get_typ(propVal, True, True))
+                    params = ['{} : ({})'.format(labelize(propName), get_typ(propVal, True, True))
                               for propName, propVal in properties.items()
                               if propName in param_names]
                     f.write('\(_params : {' + ', '.join(params) + '}) ->\n')
@@ -137,7 +147,7 @@ def main():
 
                 # If there's no fields, should be an empty record
                 if len(KVs) > 0:
-                    formatted = [" {} = {}\n".format(k, v) for k, v in KVs]
+                    formatted = [" {} = {}\n".format(labelize(k), v) for k, v in KVs]
                 else:
                     formatted = '='
                 f.write('{' + ','.join(formatted) + '} : ../types/' + modelName + '.dhall\n')

--- a/convert.py
+++ b/convert.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import requests
+import re
 
 def get_typ(props, required, importing_from_default=False):
     if '$ref' in props:
@@ -81,9 +82,10 @@ def get_static_data(modelSpec):
 
 def labelize(propName):
     """
-    If a propName contains a `$`, we have to return a quoted label
+    If a propName doesn't match the 'simple-label' grammar, we return a quoted label
+    See: https://github.com/dhall-lang/dhall-lang/blob/1d2912067658fdbbc17696fc86f057d6f91712b9/standard/dhall.abnf#L125
     """
-    if "$" in propName:
+    if not re.match("^[a-zA-Z_][\w\-/]*$", propName):
         return "`" + propName + "`"
     else:
         return propName

--- a/default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps.dhall
+++ b/default/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps.dhall
@@ -1,5 +1,5 @@
-{ $ref = ([] : Optional (Text))
-, $schema = ([] : Optional (Text))
+{ `$ref` = ([] : Optional (Text))
+, `$schema` = ([] : Optional (Text))
 , additionalItems = ([] : Optional (../types/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool.dhall))
 , additionalProperties = ([] : Optional (../types/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool.dhall))
 , allOf = ([] : Optional (List ../types/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps.dhall))

--- a/types/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps.dhall
+++ b/types/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps.dhall
@@ -1,5 +1,5 @@
-{ $ref : (Optional (Text))
-, $schema : (Optional (Text))
+{ `$ref` : (Optional (Text))
+, `$schema` : (Optional (Text))
 , additionalItems : (Optional (./io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool.dhall))
 , additionalProperties : (Optional (./io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool.dhall))
 , allOf : (Optional (List ./io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps.dhall))


### PR DESCRIPTION
Fix #19.

As mentioned there, we can merge this already (even if the dhall interpreter is not updated yet) as the generated files were broken anyways.

I'm less sure about removing the list of ignored files in `check-source`, maybe we should have it there until we get the new dhall version.

The fixed files are only two, but the failing files were several more because they were importing these two files.