### PR TITLE
Fix Kubernetes version for which to get swagger

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -91,7 +91,10 @@ def labelize(propName):
         return propName
 
 
-url = 'https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json'
+kubernetes_tag = 'v1.11.0'
+url = \
+    'https://raw.githubusercontent.com/kubernetes/kubernetes/{tag}/api/openapi-spec/swagger.json' \
+    .format(tag=kubernetes_tag)
 
 # See https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
 # because k8s API allows PUTS etc with partial data, it's not clear from the data types OR the API which


### PR DESCRIPTION
For now I think it is sufficient to hardcode this. We can come up with a better schema later.