### PR TITLE
Correct README to use Natural type

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ in let spec = defaultSpec
       ]})
   }
 } //
-{ replicas = Some Integer 2
-, revisionHistoryLimit = Some Integer 10
+{ replicas = Some Natural 2
+, revisionHistoryLimit = Some Natural 10
 }
 
 -- and here's the Deployment


### PR DESCRIPTION
I've noticed that the current example in README won't work due to the problem. It should have been fixed in #20.