### PR TITLE
Centralize Prelude import

### DIFF
--- a/Prelude.dhall
+++ b/Prelude.dhall
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/dhall-lang/Prelude/v3.0.0/package.dhall sha256:990c936c6dba21bc516c5d91a69afd908dce8c8698d6c0912798aa4ad1b978f3

--- a/Prelude.dhall
+++ b/Prelude.dhall
@@ -1,1 +1,29 @@
-https://raw.githubusercontent.com/dhall-lang/Prelude/v3.0.0/package.dhall sha256:990c936c6dba21bc516c5d91a69afd908dce8c8698d6c0912798aa4ad1b978f3
+{- This file provides a central `Prelude` import for the rest of the library to
+   use so that the integrity check only needs to be updated in one place
+   whenever upgrading the interpreter.
+
+   This allows the user to provide their own Prelude import using the
+   `DHALL_PRELUDE` environment variable, like this:
+
+   ```
+   $ export DHALL_PRELUDE='https://prelude.dhall-lang.org/package.dhall sha256:...'
+   ```
+
+   Note that overriding the Prelude in this way only works if this repository
+   is imported locally.  Remote imports do not have access to environment
+   variables and any attempt to import one will fall back to the next available
+   import.  To learn more, read:
+
+   * https://github.com/dhall-lang/dhall-lang/wiki/Safety-guarantees#cross-site-scripting-xss
+
+   This file also provides an import without the integrity check as a slower
+   fallback if the user is using a different version of the Dhall interpreter.
+
+   This pattern is documented in the dhall-nethack repo:
+
+   * https://github.com/dhall-lang/dhall-nethack/blob/master/Prelude.dhall
+-}
+
+  env:DHALL_PRELUDE
+? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v6.0.0/Prelude/package.dhall sha256:e3be3dba308637ad7ab6d4ce9a11a342b087efbf2aa801c88a05a6babaae8e48
+? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v6.0.0/Prelude/package.dhall

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ We can now expose this service out to the world with the Ingress:
 
 
 -- Prelude imports
-   let map    = https://raw.githubusercontent.com/dhall-lang/Prelude/v2.0.0/List/map
+   let map = (../Prelude.dhall).`List`.map
 
 -- dhall-kubernetes types and defaults
 in let TLS     = ../types/io.k8s.api.extensions.v1beta1.IngressTLS.dhall

--- a/api/Deployment/mkDeployment
+++ b/api/Deployment/mkDeployment
@@ -1,5 +1,5 @@
 -- Prelude
-   let Prelude = https://raw.githubusercontent.com/dhall-lang/Prelude/v3.0.0/package.dhall
+   let Prelude = ../../Prelude.dhall
 in let map  = Prelude.`List`.map
 in let kv   = Prelude.JSON.keyText
 

--- a/api/Service/mkService
+++ b/api/Service/mkService
@@ -1,6 +1,6 @@
 -- Prelude
-   let Prelude = https://raw.githubusercontent.com/dhall-lang/Prelude/v3.0.0/package.dhall
-in let kv   = Prelude.JSON.keyText
+   let Prelude = ../../Prelude.dhall
+in let kv = Prelude.JSON.keyText
 
 -- Kubernetes types and defaults
 in let Types   = ./RawTypes

--- a/examples/deploymentRaw.dhall
+++ b/examples/deploymentRaw.dhall
@@ -1,5 +1,5 @@
 -- Prelude imports
-   let map    = https://raw.githubusercontent.com/dhall-lang/Prelude/e44284bc37a5808861dacd4c8bd13d18411cb961/List/map
+   let map = (../Prelude.dhall).`List`.map
 
 -- import dhall-kubernetes types and defaults
 in let Deployment    = ../types/io.k8s.api.apps.v1beta2.Deployment.dhall

--- a/examples/ingressRaw.dhall
+++ b/examples/ingressRaw.dhall
@@ -1,5 +1,5 @@
 -- Prelude imports
-   let map    = https://raw.githubusercontent.com/dhall-lang/Prelude/v2.0.0/List/map
+   let map = (../Prelude.dhall).`List`.map
 
 -- dhall-kubernetes types and defaults
 in let TLS     = ../types/io.k8s.api.extensions.v1beta1.IngressTLS.dhall

--- a/nix/dhall-1.21.0.nix
+++ b/nix/dhall-1.21.0.nix
@@ -11,10 +11,8 @@
 }:
 mkDerivation {
   pname = "dhall";
-  version = "1.20.1";
-  sha256 = "e077e8f4945484db4e35e8ae422e9eabac1b155972602f0404d818e3e185bcdc";
-  revision = "1";
-  editedCabalFile = "1km0zbbahhq24s84s9gcck1javhplqjg51q4qf8i19iahnxkl3rq";
+  version = "1.21.0";
+  sha256 = "9b22cc6f7694ef2f5d5d6fa66727044622b9905b2a9da0cdf376c75ad3b9df0e";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
@@ -29,9 +27,9 @@ mkDerivation {
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    base containers deepseq directory doctest filepath mockery
-    prettyprinter QuickCheck quickcheck-instances serialise tasty
-    tasty-hunit tasty-quickcheck text transformers vector
+    base bytestring cborg containers deepseq directory doctest filepath
+    mockery prettyprinter QuickCheck quickcheck-instances serialise
+    tasty tasty-hunit tasty-quickcheck text transformers vector
   ];
   benchmarkHaskellDepends = [
     base bytestring containers criterion directory serialise text

--- a/nix/dhall-json-1.2.7.nix
+++ b/nix/dhall-json-1.2.7.nix
@@ -4,8 +4,8 @@
 }:
 mkDerivation {
   pname = "dhall-json";
-  version = "1.2.6";
-  sha256 = "9989a705a780ccc8b40f242e5dcb8949ade590a0180ae9559bffa25d829d2838";
+  version = "1.2.7";
+  sha256 = "11fca18fceacbff9f3b3ca86012f45b82fe9d52d2e689cfec434841a6e63e3f1";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/nix/dhall-text-1.0.16.nix
+++ b/nix/dhall-text-1.0.16.nix
@@ -1,8 +1,8 @@
 { mkDerivation, base, dhall, optparse-applicative, stdenv, text }:
 mkDerivation {
   pname = "dhall-text";
-  version = "1.0.15";
-  sha256 = "afa2dd0cbb6d261b5cf79988f673cf2405f5419c306c55181d9aae3ec6c932b2";
+  version = "1.0.16";
+  sha256 = "a1f14c45d3454e0e8a3fea91923bd186d3fa397e32119aed9d3721b907a858c2";
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -11,9 +11,9 @@ let
     packageOverrides = pkgs: rec {
       haskellPackages = pkgs.haskellPackages.override {
         overrides = haskellPackagesNew: haskellPackagesOld: rec {
-          dhall = haskellPackagesNew.callPackage ./nix/dhall-1.20.1.nix {};
-          dhall-json = haskellPackagesNew.callPackage ./nix/dhall-json-1.2.6.nix {};
-          dhall-text = haskellPackagesNew.callPackage ./nix/dhall-text-1.0.15.nix {};
+          dhall = haskellPackagesNew.callPackage ./nix/dhall-1.21.0.nix {};
+          dhall-json = haskellPackagesNew.callPackage ./nix/dhall-json-1.2.7.nix {};
+          dhall-text = haskellPackagesNew.callPackage ./nix/dhall-text-1.0.16.nix {};
           megaparsec = haskellPackagesNew.callPackage ./nix/megaparsec-7.0.2.nix {};
           repline = haskellPackagesNew.callPackage ./nix/repline-0.2.0.0.nix {};
         };


### PR DESCRIPTION
This PR centralizes the Prelude import so that:
- it gets cached
- it's easy to upgrade
- it's easy to override (so that e.g. #41 can be fixed by using the Nix derivation instead of fetching it from the internet)

The pattern is documented in [dhall-nethack](https://github.com/dhall-lang/dhall-nethack/blob/master/Prelude.dhall)