### PR TITLE
Update Dhall version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or the [full tutorial][dhall-tutorial].
 
 You can install the latest version with the following:
 ```bash
-stack install dhall-1.21.0 dhall-json-1.2.7 --resolver=nightly-2019-04-16
+stack install dhall-1.21.0 dhall-json-1.2.7 --resolver=nightly-2019-04-01
 ```
 
 ## Quickstart - main API

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ or the [full tutorial][dhall-tutorial].
 
 ## Prerequisites
 
-**NOTE**: `dhall-kubernetes` requires at least version `1.20.1` of [the interpreter](https://github.com/dhall-lang/dhall-haskell)
-(version `5.0.0` of the language).
+**NOTE**: `dhall-kubernetes` requires at least version `1.21.0` of [the interpreter](https://github.com/dhall-lang/dhall-haskell)
+(version `6.0.0` of the language).
 
 You can install the latest version with the following:
 ```bash
-stack install dhall-1.20.1 dhall-json-1.2.6 --resolver=nightly-2019-01-17
+stack install dhall-1.21.0 dhall-json-1.2.6 --resolver=nightly-2019-01-17
 ```
 
 ## Quickstart - main API

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or the [full tutorial][dhall-tutorial].
 
 You can install the latest version with the following:
 ```bash
-stack install dhall-1.21.0 dhall-json-1.2.6 --resolver=nightly-2019-01-17
+stack install dhall-1.21.0 dhall-json-1.2.7 --resolver=nightly-2019-04-16
 ```
 
 ## Quickstart - main API


### PR DESCRIPTION
cc0024e5aa440730e82cefc24f2d5dc22d3434ab bumped the Dhall version to `1.21.0`, resulting in it failing to build with version `5.0.0` of the language with the following error:
```
↳ ./example.dhall
  ↳ https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/mast
er/api/Deployment/mkDeployment
    ↳ https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/ma
ster/Prelude.dhall
      ↳ https://raw.githubusercontent.com/dhall-lang/dhall-lang/v6.0.0
/Prelude/package.dhall sha256:e3be3dba308637ad7ab6d4ce9a11a342b087efbf
2aa801c88a05a6babaae8e48
        ↳ https://raw.githubusercontent.com/dhall-lang/dhall-lang/v6.0
.0/Prelude/Text/package.dhall
          ↳ https://raw.githubusercontent.com/dhall-lang/dhall-lang/v6
.0.0/Prelude/Text/show

Error: Unbound variable: Text/show

                         Text/show
https://raw.githubusercontent.com/dhall-lang/dhall-lang/v6.0.0/Prelude
/Text/show:13:26
```

This commit updates the readme accordingly.