### PR TITLE
Show kind for error message

### DIFF
--- a/dhall-kubernetes-generator/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-kubernetes-generator/src/Dhall/Kubernetes/Convert.hs
@@ -277,4 +277,4 @@ getImportsMap objectNames folder toInclude
 
         namespaced = case filter filterFn namespacedNames of
           [name] -> name
-          wrong  -> error $ "Got more than one key! See:\n" <> show wrong
+          wrong  -> error $ "Got more than one key for "++ show kind ++"! See:\n" <> show wrong


### PR DESCRIPTION
In the case that an older kubernetes openapi is used, some of the
excluded models for newer versions will cause a necessary object for the
older kubernetes version to be filtered. In this case, showing the Kind
is helpful for debugging.