### PR TITLE
Add EarnestResearch/dhall-packages to the users

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ in
 ## Projects Using `dhall-kubernetes`
 
 * [dhall-prometheus-operator][dhall-prometheus-operator]: Provides types and default records for [Prometheus Operators][prometheus-operator].
-
+* [EarnestResearch/dhall-packages](https://github.com/EarnestResearch/dhall-packages): Provides dhall bindings for several dhall packages, including Kubernetes applications such as [argo](https://github.com/argoproj/argo), [argocd](https://github.com/argoproj/argo-cd), [ambassador](https://github.com/datawire/ambassador), [kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets) and more.
 
 ## Development
 


### PR DESCRIPTION
We are happy users of dhall and dhall-kubernetes and we opensourced our bindings, I'm proposing to add them here for better discovery :)