### PR TITLE
Add --skipDuplicates CLI flag and handler

### DIFF
--- a/dhall-kubernetes-generator/dhall-kubernetes-generator.cabal
+++ b/dhall-kubernetes-generator/dhall-kubernetes-generator.cabal
@@ -20,14 +20,15 @@ executable dhall-kubernetes-generator
   default-extensions: DeriveDataTypeable DeriveGeneric DerivingStrategies DuplicateRecordFields GeneralizedNewtypeDeriving LambdaCase RecordWildCards ScopedTypeVariables OverloadedStrings FlexibleInstances ConstraintKinds ApplicativeDo TupleSections
   ghc-options: -Wall
   build-depends:
-    base          >= 4.8.2.0   && < 5    ,
-    aeson         >= 1.0.0.0   && < 1.5  ,
-    containers    >= 0.5.0.0   && < 0.7  ,
-    dhall         >= 1.22.0    && < 1.25 ,
-    prettyprinter >= 1.2.0.1   && < 1.3  ,
-    text          >= 0.11.1.0  && < 1.3  ,
-    turtle        >= 1.5.0     && < 1.6  ,
-    vector        >= 0.11.0.0  && < 0.13
+    base                 >= 4.8.2.0   && < 5    ,
+    aeson                >= 1.0.0.0   && < 1.5  ,
+    containers           >= 0.5.0.0   && < 0.7  ,
+    dhall                >= 1.22.0    && < 1.25 ,
+    optparse-applicative >= 0.14.3.0  && < 0.15 ,
+    prettyprinter        >= 1.2.0.1   && < 1.3  ,
+    text                 >= 0.11.1.0  && < 1.3  ,
+    turtle               >= 1.5.0     && < 1.6  ,
+    vector               >= 0.11.0.0  && < 0.13
   default-language: Haskell2010
 
 source-repository head

--- a/dhall-kubernetes-generator/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-kubernetes-generator/src/Dhall/Kubernetes/Types.hs
@@ -17,6 +17,7 @@ import           GHC.Generics              (Generic)
 
 type Expr = Dhall.Expr Dhall.Src Dhall.Import
 
+type DuplicateHandler = (Text, [ModelName]) -> Maybe ModelName
 
 {-| Type for the Swagger specification.
 


### PR DESCRIPTION
This allows us to skip cases where there are object names that are re-used across namespaces.  Specifically, argo-events has a `NodeStatus` object in both the gateway and sensor namespaces.

As @amarrella pointed out, the types themselves are still accessible using fully qualified names; it is just in the aggregating/roll-up files where the types will be skipped.