### PR TITLE
Remove `--omit-empty` from Nix code

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -77,7 +77,7 @@ let
 
               in
                 ''echo './${inputFile} → ./${outputFile}'
-                  ${pkgsNew.dhall-json}/bin/dhall-to-yaml --omit-empty --file $out/${inputFile} > $out/${outputFile}
+                  ${pkgsNew.dhall-json}/bin/dhall-to-yaml --file $out/${inputFile} > $out/${outputFile}
               '';
 
         in


### PR DESCRIPTION
It's no longer necessary, although in this case it happens to
have no effect