### PR TITLE
Fix evaluation failure in CI

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -3,7 +3,6 @@ let
 
   nixpkgs = builtins.fetchGit {
     inherit (spec) url rev;
-    ref = "refs/heads/nixos-unstable";
   };
 
   overlay = pkgsNew: pkgsOld: {


### PR DESCRIPTION
Hydra complains about the branch name with:

```
hydra-eval-jobs returned exit code 1:
error: worker error: invalid Git branch/tag name 'refs/heads/nixos-unstable'
```

... and the branch name is not necessary anyway