### PR TITLE
Remove metadata.name from podTemplate

### DIFF
--- a/examples/deployment.dhall
+++ b/examples/deployment.dhall
@@ -22,7 +22,6 @@ let deployment =
           }
         , template = kubernetes.PodTemplateSpec::{
           , metadata = kubernetes.ObjectMeta::{
-            , name = Some "nginx"
             , labels = Some (toMap { app = "nginx" })
             }
           , spec = Some kubernetes.PodSpec::{

--- a/examples/deploymentSimple.dhall
+++ b/examples/deploymentSimple.dhall
@@ -10,7 +10,9 @@ let deployment =
           }
         , replicas = Some 2
         , template = kubernetes.PodTemplateSpec::{
-          , metadata = kubernetes.ObjectMeta::{ name = Some "nginx" }
+          , metadata = kubernetes.ObjectMeta::{
+            , labels = Some (toMap { name = "nginx" })
+            }
           , spec = Some kubernetes.PodSpec::{
             , containers =
               [ kubernetes.Container::{


### PR DESCRIPTION
makes it more in-line with a normal Kubernetes deployment example. This field is even ignored by kubernetes API for PodTemplates afaik

Also `deploymentSimple` was missing a `selector` which is invalid (runtime error)