### PR TITLE
Fix examples to use remote imports

### DIFF
--- a/1.17/README.md
+++ b/1.17/README.md
@@ -53,7 +53,7 @@ In the following example, we:
 -- examples/deploymentSimple.dhall
 
 let kubernetes =
-      ../package.dhall sha256:7150ac4309a091740321a3a3582e7695ee4b81732ce8f1ed1691c1c52791daa1
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:7150ac4309a091740321a3a3582e7695ee4b81732ce8f1ed1691c1c52791daa1
 
 let deployment =
       kubernetes.Deployment::{
@@ -148,7 +148,7 @@ let Prelude =
 let map = Prelude.List.map
 
 let kubernetes =
-      ../package.dhall sha256:7150ac4309a091740321a3a3582e7695ee4b81732ce8f1ed1691c1c52791daa1
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:7150ac4309a091740321a3a3582e7695ee4b81732ce8f1ed1691c1c52791daa1
 
 let Service = { name : Text, host : Text, version : Text }
 
@@ -305,6 +305,41 @@ in
 
 
 ## Development
+
+### Updating the `dhall-openapi` dependency
+
+The `dhall-openapi` dependency is a subproject of the `dhall-haskell`
+repository, so in order to upgrade `dhall-openapi` you need to update the
+reference to the `dhall-haskell` repository.
+
+To upgrade to the latest version of the `dhall-openapi` package, run:
+
+```bash
+nix-prefetch-git --fetch-submodules https://github.com/dhall-lang/dhall-haskell.git > ./nix/dhall-haskell.json
+```
+
+If you want to build against a local copy of `dhall-haskell`, then edit the
+Nix code like this:
+
+```diff
+diff --git a/nix/nixpkgs.nix b/nix/nixpkgs.nix
+index 832ae1a..810e966 100644
+--- a/nix/nixpkgs.nix
++++ b/nix/nixpkgs.nix
+@@ -126,11 +126,7 @@ let
+                    json =
+                      builtins.fromJSON (builtins.readFile ./dhall-haskell.json);
+ 
+-                   dhall-haskell = pkgsNew.fetchFromGitHub {
+-                     owner = "dhall-lang";
+-                     repo = "dhall-haskell";
+-                     inherit (json) rev sha256 fetchSubmodules;
+-                   };
++                   dhall-haskell = ~/path/to/dhall-haskell;
+ 
+                  in
+                    (import "${dhall-haskell}/default.nix").dhall-openapi;
+```
 
 ### Adding a new Kubernetes releases
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In the following example, we:
 -- examples/deploymentSimple.dhall
 
 let kubernetes =
-      ../package.dhall sha256:7150ac4309a091740321a3a3582e7695ee4b81732ce8f1ed1691c1c52791daa1
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:7150ac4309a091740321a3a3582e7695ee4b81732ce8f1ed1691c1c52791daa1
 
 let deployment =
       kubernetes.Deployment::{
@@ -148,7 +148,7 @@ let Prelude =
 let map = Prelude.List.map
 
 let kubernetes =
-      ../package.dhall sha256:7150ac4309a091740321a3a3582e7695ee4b81732ce8f1ed1691c1c52791daa1
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:7150ac4309a091740321a3a3582e7695ee4b81732ce8f1ed1691c1c52791daa1
 
 let Service = { name : Text, host : Text, version : Text }
 

--- a/docs/README.md.dhall
+++ b/docs/README.md.dhall
@@ -154,6 +154,41 @@ in
 
 ## Development
 
+### Updating the `dhall-openapi` dependency
+
+The `dhall-openapi` dependency is a subproject of the `dhall-haskell`
+repository, so in order to upgrade `dhall-openapi` you need to update the
+reference to the `dhall-haskell` repository.
+
+To upgrade to the latest version of the `dhall-openapi` package, run:
+
+```bash
+nix-prefetch-git --fetch-submodules https://github.com/dhall-lang/dhall-haskell.git > ./nix/dhall-haskell.json
+```
+
+If you want to build against a local copy of `dhall-haskell`, then edit the
+Nix code like this:
+
+```diff
+diff --git a/nix/nixpkgs.nix b/nix/nixpkgs.nix
+index 832ae1a..810e966 100644
+--- a/nix/nixpkgs.nix
++++ b/nix/nixpkgs.nix
+@@ -126,11 +126,7 @@ let
+                    json =
+                      builtins.fromJSON (builtins.readFile ./dhall-haskell.json);
+ 
+-                   dhall-haskell = pkgsNew.fetchFromGitHub {
+-                     owner = "dhall-lang";
+-                     repo = "dhall-haskell";
+-                     inherit (json) rev sha256 fetchSubmodules;
+-                   };
++                   dhall-haskell = ~/path/to/dhall-haskell;
+ 
+                  in
+                    (import "''${dhall-haskell}/default.nix").dhall-openapi;
+```
+
 ### Adding a new Kubernetes releases
 
 To add a new supported release, run:

--- a/nix/dhall-haskell.json
+++ b/nix/dhall-haskell.json
@@ -1,9 +1,7 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "05b12223f8d14055494d4c0cafc5db6807282c40",
-  "date": "2020-08-09T16:27:04+00:00",
-  "sha256": "0hgw2fq8n9v24pj3z6c28adwdmxffq5rxal12xk0vb7fvad46z42",
-  "fetchSubmodules": true,
-  "deepClone": false,
-  "leaveDotGit": false
+  "rev": "186cad7c7caf2d15c37bb5dcdac557535c648cc4",
+  "date": "2020-08-26T02:27:04+00:00",
+  "sha256": "0l5zr6di3k7934ayqd4rv3z8sjy55h2klvnqrd6k7adfk8ycnd97",
+  "fetchSubmodules": true
 }

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -108,7 +108,7 @@ let
               in
                 pkgsNew.lib.optionalString (version == preferredVersion)
                 ''echo './${inputFile} → ./${outputFile}'
-                  ${pkgsNew.dhall}/bin/dhall text --file $out/${inputFile} > $out/${outputFile}
+                  ${pkgsNew.dhall}/bin/dhall text --file $out/${inputFile} | ${pkgsNew.gnused}/bin/sed 's_\.\./package.dhall_https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall_g' > $out/${outputFile}
                 ''
             }
           '';


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-kubernetes/issues/140

This also fixes the upstream `README.dhall` to include the new instructions for the Development section