### PR TITLE
Make `apiVersion` and `kind` optional in PersistentVolumeClaim default

### DIFF
--- a/1.12/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/1.12/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,5 +1,5 @@
-{ apiVersion = "v1"
-, kind = "PersistentVolumeClaim"
+{ apiVersion = Some "v1"
+, kind = Some "PersistentVolumeClaim"
 , spec = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
 , status = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimStatus.dhall
 }

--- a/1.13/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/1.13/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,5 +1,5 @@
-{ apiVersion = "v1"
-, kind = "PersistentVolumeClaim"
+{ apiVersion = Some "v1"
+, kind = Some "PersistentVolumeClaim"
 , spec = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
 , status = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimStatus.dhall
 }

--- a/1.14/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/1.14/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,5 +1,5 @@
-{ apiVersion = "v1"
-, kind = "PersistentVolumeClaim"
+{ apiVersion = Some "v1"
+, kind = Some "PersistentVolumeClaim"
 , spec = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
 , status = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimStatus.dhall
 }

--- a/1.15/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/1.15/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,5 +1,5 @@
-{ apiVersion = "v1"
-, kind = "PersistentVolumeClaim"
+{ apiVersion = Some "v1"
+, kind = Some "PersistentVolumeClaim"
 , spec = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
 , status = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimStatus.dhall
 }

--- a/1.16/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/1.16/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,5 +1,5 @@
-{ apiVersion = "v1"
-, kind = "PersistentVolumeClaim"
+{ apiVersion = Some "v1"
+, kind = Some "PersistentVolumeClaim"
 , spec = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
 , status = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimStatus.dhall
 }

--- a/1.17/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/1.17/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,5 +1,5 @@
-{ apiVersion = "v1"
-, kind = "PersistentVolumeClaim"
+{ apiVersion = Some "v1"
+, kind = Some "PersistentVolumeClaim"
 , spec = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
 , status = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimStatus.dhall
 }

--- a/1.18/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/1.18/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,5 +1,5 @@
-{ apiVersion = "v1"
-, kind = "PersistentVolumeClaim"
+{ apiVersion = Some "v1"
+, kind = Some "PersistentVolumeClaim"
 , spec = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
 , status = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimStatus.dhall
 }

--- a/1.19/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/1.19/defaults/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,5 +1,5 @@
-{ apiVersion = "v1"
-, kind = "PersistentVolumeClaim"
+{ apiVersion = Some "v1"
+, kind = Some "PersistentVolumeClaim"
 , spec = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
 , status = None ./../types/io.k8s.api.core.v1.PersistentVolumeClaimStatus.dhall
 }


### PR DESCRIPTION
The types got updated to make apiVersion and kind optional a while back, but the defaults got left behind. This PR should make them match