### PR TITLE
Update dhall-openapi

### DIFF
--- a/1.12/defaults.dhall
+++ b/1.12/defaults.dhall
@@ -23,7 +23,7 @@
 , ControllerRevisionList =
     ./defaults/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:2343b690c1c4d49b5e1fe09da5a71fc9e8c74f2a9975764b0ad41cf597b6b616
 , DaemonSet =
-    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:059f8dce8d03567d610ba7863258d1854b91b256b1225aff0043d566b3028b0b
+    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:7cb364d49b6d8c19afb26102ce697cfa2461989d524ae9d4143b3552a958854d
 , DaemonSetCondition =
     ./defaults/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , DaemonSetList =
@@ -35,7 +35,7 @@
 , DaemonSetUpdateStrategy =
     ./defaults/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:0267659f9e8647bbf2e9f9073536c4c0c60b8ff1c076523cd7773b05e8d1c270
 , Deployment =
-    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:a52d7b28fc1d0713e1d2d5be2b231d3036d7ff7654eebd869c217d2eaf6e626e
+    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:f3daed0c286c800c248870e6cbcfa3a98f48a57edd3053eacc12e75fb734824a
 , DeploymentCondition =
     ./defaults/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:006ebe956ae6e2918eb18beed3f6378d0f79437bfc449f4b6c7852206a7c7e5d
 , DeploymentList =
@@ -47,13 +47,13 @@
 , DeploymentStrategy =
     ./defaults/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:e5ba779274cb5a0b72069647e1aa8b257380ddb3b183aef45233028c399f65b9
 , ReplicaSet =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:1bbda4033041eb56831a3741bf1ea96bbc0c598c03d8e44275cfb6f7e7c16bb6
+    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:c507987242fd912de78201a7b5dbd215d0db3abd99d9035d5e0891fd9494d7d9
 , ReplicaSetCondition =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicaSetList =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:e57739bf261dfcdaec492632f1986b57c7d7bc45a4ba7be145beb64b739fe70f
 , ReplicaSetSpec =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:f0f154a3f75bed435079855401b80f2e3a842e0254db77a7f6883c6481f03aac
+    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:0f681963ef0045b595b2b4fdfc4a0501977a1c67ffdefdf6c5309ccea09be2de
 , ReplicaSetStatus =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , RollingUpdateDaemonSet =
@@ -63,7 +63,7 @@
 , RollingUpdateStatefulSetStrategy =
     ./defaults/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:4d9feb8034f9f58692aebeed06474c07c387e5b8bc11c40dc36ec6390a26fa63
 , StatefulSet =
-    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:1cd2a37ff9e72803b67f266ef0a0074eb7a060fe7f332a6079d0b3234e28fd49
+    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:60aad5054a26fa1886e2498b9f2311977359f59f0e3e2c7370a437ce6e22ad1a
 , StatefulSetCondition =
     ./defaults/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , StatefulSetList =
@@ -153,7 +153,7 @@
 , ResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Job =
-    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:bbea978a7fa433c81e938451e96a31b623df66cee6d4b8b9eaea810792c0bd6e
+    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:d3d2e83231ffa788f98ebcf24a02aed9d05f75d417c1d78bdd8847ff67b088fc
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
 , JobList =
@@ -163,7 +163,7 @@
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall sha256:acf4f792ff1e56e53cb6d00ddc60f6ade85c44289efcbbfd2e5b81e1ac0347fc
 , CronJob =
-    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:8d0a7f7482d98c1e0cefd64dd25032381e86d976026016edcfc5d3e61dc08744
+    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:c88a7306457299af2d412431badcdee443d421246c5ae3857a0625fc9d1bad8d
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:d6f792b6d1f5cc8e862708490973d8b46eeb2d7adf4f3be3170a93ce2b70be7a
 , CronJobSpec =
@@ -171,7 +171,7 @@
 , CronJobStatus =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:751a6c74f8753d8467f43f76bc3b0661655a65daf9f907f6f814f01ade0fcd70
 , JobTemplateSpec =
-    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:742ca338555765280ecd38497e67b0350c9010c13a04ac283b5ba63cda7e8d03
+    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:774abc24b7fcd1a00324613e45a4c86d2332301a6b18405a07026c0974d234a1
 , CertificateSigningRequest =
     ./defaults/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:fc1ae5e4b43cbc3d6410fce82d6859e180c77ce5b9c643b2562588f85e1ab780
 , CertificateSigningRequestCondition =
@@ -425,11 +425,11 @@
 , PodStatus =
     ./defaults/io.k8s.api.core.v1.PodStatus.dhall sha256:bfe78f7e337e9b29e89d26cb8e8a0cf9565e1fae36a61f0623f53d44f5dfcb4f
 , PodTemplate =
-    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:8aeaa42695f3d1f84f47a98205eb0644850ba2df9ccbd8a9371120d8510ed6f7
+    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:84af6f7ec6bdcc46b0ea304adc97a6c4fbd414c40deeebbc9e656e7328dca2be
 , PodTemplateList =
     ./defaults/io.k8s.api.core.v1.PodTemplateList.dhall sha256:51ca93c255c7ab48ec42245f8b34a4effdd072cd019931f37ef304d8b46d6e6f
 , PodTemplateSpec =
-    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:ce18592c51325d0cf18e0f6c1fcf59e3ce760ceab779e7c66883d066204f94a9
+    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:630c6fd49236cc7c8f2e0e825b709c819c38937a3158c24e959ba25c26890dc3
 , PortworxVolumeSource =
     ./defaults/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:5d8e73366d928941a81088f57aaf538a8c3a8d171086228dcefe3aa8084e6a0a
 , PreferredSchedulingTerm =
@@ -445,13 +445,13 @@
 , RBDVolumeSource =
     ./defaults/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:0c1b0c6ed400fe9c63c9a97d77d6d6a69463137e0e43687c4087b7e8cce747c3
 , ReplicationController =
-    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:aa39589bcc7e7ce27ef4b2e36d7d36166b072541a3b0619fe8790500b19f7135
+    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:68c1847ec8b47a47ef550d2736c42455b0f2cbd6280b7bcf03379e6866e8dbb2
 , ReplicationControllerCondition =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicationControllerList =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:e7dcae86af1b284f62a6f26fe1e432a6a27a9fa5c3100acdad84794ac21ed769
 , ReplicationControllerSpec =
-    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:ba50ee773c10bcd75613b003af8ed51e25f6699ed68c990ee8adf532a6b79686
+    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:be106b4f05455198a0822cbff4bdec3d0056bb2f45feb3cb85016818bfcfdc2e
 , ReplicationControllerStatus =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , ResourceFieldSelector =

--- a/1.12/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.12/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.12/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.12/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.12/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.12/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall
+}

--- a/1.12/package.dhall
+++ b/1.12/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:e4ffc8f3298395316fc675cd698f8ec4822c922b642cd76fcc9dffc6c392bbde
+  ./schemas.dhall sha256:7c4c25a75cbaa353f868100589cd77f9fe5f57790d67802bf53fd45c6335ad0a
 ∧ { IntOrString =
-      ( ./types.dhall sha256:c34104edfd0afd6c335cb607bfaa521667c48be98251f07c7ba38b99339ea66f
+      ( ./types.dhall sha256:b94712b1dbbd4c68846d3d19e545d4779cfdf0d1009e66c9f73383cc87ecaa77
       ).IntOrString
   , Resource =
-      ./typesUnion.dhall sha256:25d6f0527f9d83663af22313a61f7c4a3a8a6451a0a61855a7c377a3cc86fb1e
+      ./typesUnion.dhall sha256:3901dec174251cdd2e36ae5dd26071b0659ea0979b7ac39053ec2397b3435cbb
   }

--- a/1.12/schemas.dhall
+++ b/1.12/schemas.dhall
@@ -23,37 +23,37 @@
 , ControllerRevisionList =
     ./schemas/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:60bccd5a71d411feffc31aba6f4ec3c61f0ceee9c624cd8a024c7e0fe4d3ba27
 , DaemonSet =
-    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:3217a9bca62009b0cc482eec592cf06778001b9fc64d261e5c20cba9534e0b90
+    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:34e65e0b311e61397eb4cec80c59a4ce27cd4ba5d62651d7f6940429b25d7b7e
 , DaemonSetCondition =
     ./schemas/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , DaemonSetList =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:774228190b581e1416d1859be8bb1afe2ddd9a977ca28a5bf1d791ba1737921b
+    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:e939c588dc164645966d036d75c87f4703fa70c21e8ff2fe4ecf8cd036b0fa74
 , DaemonSetSpec =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:817a30ea4180340d03ac78e2368eff66102a4fc26a13555e09a8022f3a7900e0
+    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:faee42b7142caca23a3fa0b0c705370f38475cd2b4af18c5126b17834284cc85
 , DaemonSetStatus =
     ./schemas/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:a68e46f267e6a5071080338953f8b1d13dff20cbfc06ae4b25f7645ff0b6cff6
 , DaemonSetUpdateStrategy =
     ./schemas/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:3efad19fff60b45006bb76c1bb6bd872e33a62d006dc6c6cd699c5945342814a
 , Deployment =
-    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:f5d825d64496b83d35db2438c4095db9a205b66c986a62cc9144a0a75ad797ed
+    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:dbb4ea0e904169b4fa64bc30f06add5cecb45a4c3e141a929dd2096a491a0f30
 , DeploymentCondition =
     ./schemas/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:f6d653c489ad36f5ef1c422a5a8297e7e73b95210cc0e4224611c6188bad3fd5
 , DeploymentList =
-    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:07a3138a253deef53e53a4da02a0d28b735e75db292d3f8c1a19081d7118e4b0
+    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:9470290c5bece760a1ca6d54b84319b9821b9c62be296cf447bfa9e30e3f80e8
 , DeploymentSpec =
-    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:0a09161f1e76fb93eb374dd1465fcab7d87bb0de797de3b46fa6acb43acc42f8
+    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:22fb445fc8c4ff2661ed5972cbfd274566e243d39d98a71e000afc25c8158f3c
 , DeploymentStatus =
     ./schemas/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:6c1a6f0ab5f98b0ae2aa9d861ea0ede60adbf94b1e21f0e2be39d6abe21bda39
 , DeploymentStrategy =
     ./schemas/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:f6893d857d85ff5bf089070c9a3416026483331e40c3999c52dc17d9a06bdecd
 , ReplicaSet =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:dc9145c846e235b071764ee4eaee5ef4e7b503b9255e547bce25f7ec1f8f08a4
+    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:cf39c92c052a679aed16343a8e7135fec9aa24847d90a8444e8af4475b52f59b
 , ReplicaSetCondition =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicaSetList =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:088e21af4c382b787cc1970535a6116bef8b1ebf9f6fbe5797bd08852228caaf
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:3a73129097f09a1130357d2b1ff2b2a3bfdaef0731b9ab60ccf34ceb53af89cd
 , ReplicaSetSpec =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:6e2a2513d3cea12f2cfe03d996592208a1f78958cf9f441904e7ca5688d63ba1
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:979eb36b9c10394d2ae218a2eadea8500a7a191166cc9ed1912ae855905194f1
 , ReplicaSetStatus =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , RollingUpdateDaemonSet =
@@ -63,13 +63,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./schemas/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:0471cec7aab65313bb60ff3f774ee8d8c8e406f16b34f3dd27b50659055acecb
 , StatefulSet =
-    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:406e2db1218cb2ce1a4c377bdea5b631cab339d781c237bce00e7d82e99fb490
+    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:7f120701a8456f7f8869b7c6a31c80a9bf9e2b2f5ee96a45ad8ba1af1493cd2a
 , StatefulSetCondition =
     ./schemas/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , StatefulSetList =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:9817c299e8b7ad0ab082a4db7394b81d5d86b436e40b928224a757a928b580fd
+    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:2babc2524b74a889e33392d4c5efb5d8099f72eb92502963b4923a44d4ccddb0
 , StatefulSetSpec =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:7402548114c9f12c39bc8c2a2d6a3e32c76bbd75e0a67814c549e952a2b9218f
+    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:740844c8be27a8553d26a11a7db68cc6036a1fdecca8611ea771424f724cb5c4
 , StatefulSetStatus =
     ./schemas/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:a490d193b72e53cbb9b1fe35dde9bc02415e3f01bf8ce8a516ddbad25855df42
 , StatefulSetUpdateStrategy =
@@ -153,25 +153,25 @@
 , ResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , Job =
-    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:6c716dfc5d7cbee8a2e1d83eb3a7eac061026021c629a53d6e739e4ba4535e73
+    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:50af913ad9873a1008bfc90679f099f2f7e7a4c0462bdff0d388a88cb6bbe44e
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
-    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:722d7d793d96cb02344d75452c6aeda189dbdf84ab13197f8557f779aa83f567
+    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:b13e25748316337a45c9ecd66de72d1e0d60e5eec5c25790758cf91ec43c8603
 , JobSpec =
-    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:bd409c86fd3609f5bececd9374164fb41fe8650c27bd586482eaae2cbe26aa18
+    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:19fcdfbdf801980b83c9505c4f7ed68e363370d086866be97efd3ad5c2993c00
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall sha256:ddbf73e9d4be060bdfb9aabc84c1ad30860a6ac6b37fcdbff7bbae8e473a33c1
 , CronJob =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:1d6d7c34ced8db1ae020eee8ffcc2792b58c731b5edd5e9753bf5f2d49a7c8a3
+    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:49b9db448fe1cf044a9dc5e64ce97b8f7d9ab9a36048039219055ae7c89df113
 , CronJobList =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:ee350610911fdbddbbf0027dea9680ecbfb9ac1a30a058caf51e5e497f46231e
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:c6bec06e625dd352bdb3c94c7d63715dc3e2f68c6ebf49050e0614490e90b4e2
 , CronJobSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:1764619031c613c4f1ad8c0e0be432fd12701efa63efa8ef22804024a6dbcf81
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:f4e4a5fb503ae7bec19d4d99c3dc3072b0b2dad4c96c5248b4dc42b9c13640ed
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:aaef515cade329c5c1bccb54d90e32c20c3b7bcb96ffdee38650292cf56c10d4
 , JobTemplateSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:4722aa4bcec238eb61f8f920d6c1c9866097d5f10a333763556442c94af57bab
+    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:4c97ae79b22f4f444c7586b92aaf7dd2b92f1bff96ce6da59cb854c6bf813633
 , CertificateSigningRequest =
     ./schemas/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:aaec32ab8e6b2b4ea66b21fe57cc534feb71cc82a60446369a13e15768610a7b
 , CertificateSigningRequestCondition =
@@ -425,11 +425,11 @@
 , PodStatus =
     ./schemas/io.k8s.api.core.v1.PodStatus.dhall sha256:3f3b362bc1cce319352f71c211fe1e0540c74783ca52dc284b1dd81fde5dba59
 , PodTemplate =
-    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:ac1ca3b21e56d505c735807ac7c09473dce458e94836c98658713dfe70797643
+    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:d13739f509d763371f9426f2cb167832e4a3a1f176e8232392d161285f0e3158
 , PodTemplateList =
-    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:45bb11cafa02bbf2407d6919396f32ef0a1e6d59c0229db8bfeb0ed0463043d1
+    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:192d465e59ce7fd799eb0504638a3dc3f89f1bc890991593f27736943c8034be
 , PodTemplateSpec =
-    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:5ad411b0b136263512646b9ff2272d9e13074d1c64140f1d1e3db54085aca836
+    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:27e754934fded91cf35147ebc22e1bcf04b1773da2c6d5e8b0882f4c6a49b6d0
 , PortworxVolumeSource =
     ./schemas/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:b0bf02de5706c9f17b2dfb7f5938941151708cffc2bf1e4c69ca4a9ed1e4b735
 , PreferredSchedulingTerm =
@@ -445,13 +445,13 @@
 , RBDVolumeSource =
     ./schemas/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:ac07443af1c9f57e0175d9468507c2259feee9ea807f71ba4f5383658d62cd36
 , ReplicationController =
-    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:74ccb622e836d44d57dcd483dd15aabc8a248cfefbf1a25b3900f63811080322
+    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:1dc3b9f861e6c4872d76ad528e17395b82c187c6629e14bf1f70d65260515589
 , ReplicationControllerCondition =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicationControllerList =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:ab8e520649f6e640eb94f69c6dea59df6983856d1957bff7f6b4c4ab86fb6110
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:893d1b5289734ae78b87aacc91931a2ec9d57b1b369b30db5c35611e9896ca96
 , ReplicationControllerSpec =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:b43446eedc80b4ee847c71772f4f162a49182b011ab78cf49007f0e3b1d9fc83
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:af79b5b51895e5b52950c1ecb617a312f5a1cc41793b5517222030001f287b52
 , ReplicationControllerStatus =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , ResourceFieldSelector =

--- a/1.12/types.dhall
+++ b/1.12/types.dhall
@@ -23,37 +23,37 @@
 , ControllerRevisionList =
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:741a3888ecced1bbd85b27a289cac3fd393866f1a488a036676b942190d11215
 , DaemonSet =
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:50e7f328b7150bf376877c30ec0943c364772a9fe7f46feea08c4c470638b8f2
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:0b872eec0a30604cddd0a534d6cba7763f90e55b6e8af2182ecc55786265e964
 , DaemonSetCondition =
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , DaemonSetList =
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:31ce709a852ac43d40ef85b408502bb11b58ff0ec5d94006e93a6bc365b9a5ba
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:a1b5b9c76350ac6c108e348b2bfd6db75925cafc23546946a2b33b551beeeee1
 , DaemonSetSpec =
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:a3bee8bca9a29a6bb15112ec70c126d2d72deeb12e25fd443c8d4c0a84642dc7
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:7632baf49d34ea74bc8094ea90fccd871d77931d91a552a6dc3a16efe1debffc
 , DaemonSetStatus =
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 , DaemonSetUpdateStrategy =
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 , Deployment =
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:7efe3fd710cc06a8caa7c8998d59110beeab47627f399b6386b3dcddb79a06c5
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:d3526310a8bf7a680f24db12e8d765982f44a987e1cec5cd124138b2a5770a8d
 , DeploymentCondition =
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 , DeploymentList =
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:ce55ed74ec1ad68d3c3b2b1fada4cb592b24cfe416c8b92d9acb5e6ae09c4eab
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:65477a87fbb6741964c7db516a1cc4100db72a788ca66df2b553322a1201f1b8
 , DeploymentSpec =
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:3b399aec5ab76ec765251c0909d652fd32afc517876813be953e53ef5491eb31
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:662fdaba332ef053f01137795138614c87debce2f799eece8e78ba47d6c7f9e2
 , DeploymentStatus =
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 , DeploymentStrategy =
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 , ReplicaSet =
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:433ceb07ce53ea7160db4eb5c13d1d8fa62a9a55a4e40dd10ecbad22606b8450
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:26929ace57385820e462aa58260ed073c8def3539ced85abfd6fba64074d8c76
 , ReplicaSetCondition =
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicaSetList =
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:d9e47eb6beeb46c4686b8383dce3375eb962142529beb50cf13890a27b31570b
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:f00f1a16018481f16d2bd68843a9501c117140441b46daf09343ffb7e21f0271
 , ReplicaSetSpec =
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:45263983ab634d28cc9cbf53c239a9f257c4ff783eac5194312971f8336bb14e
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:cfc357a246cdb78924e9f7800891c6c3f230b9b04ceae9a86b5725e14c3003a8
 , ReplicaSetStatus =
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , RollingUpdateDaemonSet =
@@ -63,13 +63,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 , StatefulSet =
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:f292a854900f03def4081485bd3503cf836a68c15b843b5adbd16fcfd36ddc84
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:4125c126f6517c201c50fe5b6d8252b6b37d0a85523e287a2613584988f246b3
 , StatefulSetCondition =
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , StatefulSetList =
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:979a936c0e884a731fd79e024d6ccea724d88784e102917c41b5c643c75c8a51
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:8550986ff0852e465e6b52ba2a37efb91e4ac49ae0e383977f53bb695208e067
 , StatefulSetSpec =
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:77b0937e89668ef16ede26c456a6695fe1a100dccb67ea2c2206761b8fd72ee4
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:e0fc769ef18f9e119eef8519bac6f40f6877564994d1bc620cdc7c4bbb45b970
 , StatefulSetStatus =
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 , StatefulSetUpdateStrategy =
@@ -153,25 +153,25 @@
 , ResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , Job =
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:f83a7363e5d3489f7ef1aec571af27dbe93b9a615a8cd8412b0086ac01fcc281
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:03bf3d204c8b5e3c9d19a55f36dfa18be73b31427c9985cbba63e59363a9e9dc
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:52dc666a656b58d28a928167abceff42a2be0baa6e5d31182b388c9b5e82d4a9
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:3a4aedc867de11fb7181f2fb9305531a836e3aeb35a9b69022ad1bf021682972
 , JobSpec =
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:e78937a0db67506b24d4f44bec5df424e2b5fffb44a9c291403d5ce576065602
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:be21b378b42dae984249af9a675260a1353e72c15a85961a834a888bcbb525c7
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 , CronJob =
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:5fc96e6431adf73db7633925af71d771332d69e08302f4237a9c749f3496b5cd
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:899973a6889135a9570484e2502d2ff647df5bc85f8a004c45181fc1f617a7ab
 , CronJobList =
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:5bfcd61e2f591be494aafccbc542121fc787b065aebe60b95942d023951d8c13
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:88e2f294e59d1a06c27e3f30ece6d7b8bd8cb91ac8a2d72fdb814444efedf3fa
 , CronJobSpec =
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:f8af1cb12153d2b3d5d1e32f060d028e54d04dda5fced2ddb86af778937a2e83
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:a790588e99e3fbe2810691618250c8cc4f0491c1ce56383bbe5f56f6b803046d
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 , JobTemplateSpec =
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:aa7057665d7d30ad782a51bbf40d4e4a42a4777e006470945761578ee0a69573
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:225aff5377f0e26cae0eec77c0947724fb64760a76ba93750e92f0c16897bf20
 , CertificateSigningRequest =
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:67dde39719f3f030cd948ea6bd21cf0d987b0799c03490c1e6d22600007f4259
 , CertificateSigningRequestCondition =
@@ -425,11 +425,11 @@
 , PodStatus =
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:391332987a601de8c7eb411e62d54495dd8231e7104c4e3f22043b6aea26319f
 , PodTemplate =
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:31997058286f45b00247be03f5339e0d3dffbcc870851c253b3580af9e3babfb
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:f175ec172ccb275113dd9674298a046bac5fa130f83f018b0ab43f560f6a867d
 , PodTemplateList =
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:0da09fc7d59b7959302b96b9091e011ec4ae6823b26c44641f85a452acc332d3
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:89c023701b27939441085a515b33856f2cc3eb126d58b725cfe5f9efc07d14f2
 , PodTemplateSpec =
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:c5a26f928e1dcdc53e39e7dd1892032e56be44d27aefa7b188de1116a4c5bbcb
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:894207e4c99da0280977fdbcf5d5f3dc352d93326cc60153c4953fb68deda866
 , PortworxVolumeSource =
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 , PreferredSchedulingTerm =
@@ -445,13 +445,13 @@
 , RBDVolumeSource =
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 , ReplicationController =
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:61f77c1b5efe2c8e17750a59b6b9df6754eb023f3fd03f02b09ce08ac24cbb16
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:b03c41dbb8a4d54d5092377df16e0e5739a11d85f02e5589fd246e9320c8de87
 , ReplicationControllerCondition =
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicationControllerList =
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:74bc2e01ea20dc8a4ef4c2736952cb518b2be9499eeb72c655a5f9b975a39268
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:d23fa7ba4fa58054e93cece426226d727a8af58d81ea609a7edf2517cc1c5680
 , ReplicationControllerSpec =
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:154bc862f9f2da941eb07566bf32abb625b2f4a9164e3938635bb70875fd388c
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:31a6d0c736d9d153f8122f557f0b5e61e02f56cacf745b5c0e70cee8444e4191
 , ReplicationControllerStatus =
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , ResourceFieldSelector =

--- a/1.12/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.12/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.12/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.12/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.12/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.12/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.core.v1.PodSpec.dhall
 }

--- a/1.12/typesUnion.dhall
+++ b/1.12/typesUnion.dhall
@@ -23,37 +23,37 @@
 | ControllerRevisionList :
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:741a3888ecced1bbd85b27a289cac3fd393866f1a488a036676b942190d11215
 | DaemonSet :
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:50e7f328b7150bf376877c30ec0943c364772a9fe7f46feea08c4c470638b8f2
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:0b872eec0a30604cddd0a534d6cba7763f90e55b6e8af2182ecc55786265e964
 | DaemonSetCondition :
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | DaemonSetList :
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:31ce709a852ac43d40ef85b408502bb11b58ff0ec5d94006e93a6bc365b9a5ba
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:a1b5b9c76350ac6c108e348b2bfd6db75925cafc23546946a2b33b551beeeee1
 | DaemonSetSpec :
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:a3bee8bca9a29a6bb15112ec70c126d2d72deeb12e25fd443c8d4c0a84642dc7
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:7632baf49d34ea74bc8094ea90fccd871d77931d91a552a6dc3a16efe1debffc
 | DaemonSetStatus :
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 | DaemonSetUpdateStrategy :
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 | Deployment :
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:7efe3fd710cc06a8caa7c8998d59110beeab47627f399b6386b3dcddb79a06c5
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:d3526310a8bf7a680f24db12e8d765982f44a987e1cec5cd124138b2a5770a8d
 | DeploymentCondition :
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 | DeploymentList :
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:ce55ed74ec1ad68d3c3b2b1fada4cb592b24cfe416c8b92d9acb5e6ae09c4eab
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:65477a87fbb6741964c7db516a1cc4100db72a788ca66df2b553322a1201f1b8
 | DeploymentSpec :
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:3b399aec5ab76ec765251c0909d652fd32afc517876813be953e53ef5491eb31
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:662fdaba332ef053f01137795138614c87debce2f799eece8e78ba47d6c7f9e2
 | DeploymentStatus :
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 | DeploymentStrategy :
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 | ReplicaSet :
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:433ceb07ce53ea7160db4eb5c13d1d8fa62a9a55a4e40dd10ecbad22606b8450
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:26929ace57385820e462aa58260ed073c8def3539ced85abfd6fba64074d8c76
 | ReplicaSetCondition :
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicaSetList :
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:d9e47eb6beeb46c4686b8383dce3375eb962142529beb50cf13890a27b31570b
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:f00f1a16018481f16d2bd68843a9501c117140441b46daf09343ffb7e21f0271
 | ReplicaSetSpec :
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:45263983ab634d28cc9cbf53c239a9f257c4ff783eac5194312971f8336bb14e
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:cfc357a246cdb78924e9f7800891c6c3f230b9b04ceae9a86b5725e14c3003a8
 | ReplicaSetStatus :
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | RollingUpdateDaemonSet :
@@ -63,13 +63,13 @@
 | RollingUpdateStatefulSetStrategy :
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 | StatefulSet :
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:f292a854900f03def4081485bd3503cf836a68c15b843b5adbd16fcfd36ddc84
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:4125c126f6517c201c50fe5b6d8252b6b37d0a85523e287a2613584988f246b3
 | StatefulSetCondition :
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | StatefulSetList :
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:979a936c0e884a731fd79e024d6ccea724d88784e102917c41b5c643c75c8a51
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:8550986ff0852e465e6b52ba2a37efb91e4ac49ae0e383977f53bb695208e067
 | StatefulSetSpec :
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:77b0937e89668ef16ede26c456a6695fe1a100dccb67ea2c2206761b8fd72ee4
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:e0fc769ef18f9e119eef8519bac6f40f6877564994d1bc620cdc7c4bbb45b970
 | StatefulSetStatus :
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 | StatefulSetUpdateStrategy :
@@ -153,25 +153,25 @@
 | ResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | Job :
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:f83a7363e5d3489f7ef1aec571af27dbe93b9a615a8cd8412b0086ac01fcc281
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:03bf3d204c8b5e3c9d19a55f36dfa18be73b31427c9985cbba63e59363a9e9dc
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:52dc666a656b58d28a928167abceff42a2be0baa6e5d31182b388c9b5e82d4a9
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:3a4aedc867de11fb7181f2fb9305531a836e3aeb35a9b69022ad1bf021682972
 | JobSpec :
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:e78937a0db67506b24d4f44bec5df424e2b5fffb44a9c291403d5ce576065602
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:be21b378b42dae984249af9a675260a1353e72c15a85961a834a888bcbb525c7
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 | CronJob :
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:5fc96e6431adf73db7633925af71d771332d69e08302f4237a9c749f3496b5cd
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:899973a6889135a9570484e2502d2ff647df5bc85f8a004c45181fc1f617a7ab
 | CronJobList :
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:5bfcd61e2f591be494aafccbc542121fc787b065aebe60b95942d023951d8c13
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:88e2f294e59d1a06c27e3f30ece6d7b8bd8cb91ac8a2d72fdb814444efedf3fa
 | CronJobSpec :
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:f8af1cb12153d2b3d5d1e32f060d028e54d04dda5fced2ddb86af778937a2e83
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:a790588e99e3fbe2810691618250c8cc4f0491c1ce56383bbe5f56f6b803046d
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 | JobTemplateSpec :
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:aa7057665d7d30ad782a51bbf40d4e4a42a4777e006470945761578ee0a69573
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:225aff5377f0e26cae0eec77c0947724fb64760a76ba93750e92f0c16897bf20
 | CertificateSigningRequest :
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:67dde39719f3f030cd948ea6bd21cf0d987b0799c03490c1e6d22600007f4259
 | CertificateSigningRequestCondition :
@@ -425,11 +425,11 @@
 | PodStatus :
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:391332987a601de8c7eb411e62d54495dd8231e7104c4e3f22043b6aea26319f
 | PodTemplate :
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:31997058286f45b00247be03f5339e0d3dffbcc870851c253b3580af9e3babfb
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:f175ec172ccb275113dd9674298a046bac5fa130f83f018b0ab43f560f6a867d
 | PodTemplateList :
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:0da09fc7d59b7959302b96b9091e011ec4ae6823b26c44641f85a452acc332d3
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:89c023701b27939441085a515b33856f2cc3eb126d58b725cfe5f9efc07d14f2
 | PodTemplateSpec :
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:c5a26f928e1dcdc53e39e7dd1892032e56be44d27aefa7b188de1116a4c5bbcb
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:894207e4c99da0280977fdbcf5d5f3dc352d93326cc60153c4953fb68deda866
 | PortworxVolumeSource :
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 | PreferredSchedulingTerm :
@@ -445,13 +445,13 @@
 | RBDVolumeSource :
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 | ReplicationController :
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:61f77c1b5efe2c8e17750a59b6b9df6754eb023f3fd03f02b09ce08ac24cbb16
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:b03c41dbb8a4d54d5092377df16e0e5739a11d85f02e5589fd246e9320c8de87
 | ReplicationControllerCondition :
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicationControllerList :
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:74bc2e01ea20dc8a4ef4c2736952cb518b2be9499eeb72c655a5f9b975a39268
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:d23fa7ba4fa58054e93cece426226d727a8af58d81ea609a7edf2517cc1c5680
 | ReplicationControllerSpec :
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:154bc862f9f2da941eb07566bf32abb625b2f4a9164e3938635bb70875fd388c
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:31a6d0c736d9d153f8122f557f0b5e61e02f56cacf745b5c0e70cee8444e4191
 | ReplicationControllerStatus :
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | ResourceFieldSelector :

--- a/1.13/defaults.dhall
+++ b/1.13/defaults.dhall
@@ -21,7 +21,7 @@
 , ControllerRevisionList =
     ./defaults/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:2343b690c1c4d49b5e1fe09da5a71fc9e8c74f2a9975764b0ad41cf597b6b616
 , DaemonSet =
-    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:42f2ff2097df008a67a1464d7547572267848a18e9e04b1ae4cc8210bc31ff00
+    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:1a4f48566241a5e7e7a56a39129a76f2468a1ec7e35fe84629620d5354857089
 , DaemonSetCondition =
     ./defaults/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , DaemonSetList =
@@ -33,7 +33,7 @@
 , DaemonSetUpdateStrategy =
     ./defaults/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:0267659f9e8647bbf2e9f9073536c4c0c60b8ff1c076523cd7773b05e8d1c270
 , Deployment =
-    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:612f6203b112f3682b9213cbd7f4fe8ff0977403a88ebf8a823ce1e46123d3f4
+    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:d7830f0eb2f9cce72afac208cfcd62d1601efd432e0413a62ded3836b2e2386b
 , DeploymentCondition =
     ./defaults/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:006ebe956ae6e2918eb18beed3f6378d0f79437bfc449f4b6c7852206a7c7e5d
 , DeploymentList =
@@ -45,13 +45,13 @@
 , DeploymentStrategy =
     ./defaults/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:e5ba779274cb5a0b72069647e1aa8b257380ddb3b183aef45233028c399f65b9
 , ReplicaSet =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:d32ca3f3efcdfe6f7568b109fb479bc8ac4266fe947e90aa34225b8cd08c5bac
+    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:9273067268f2dfb23bab3c91e9c2000f2ec538fbab5b48911b1aa63bd9ab51e6
 , ReplicaSetCondition =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicaSetList =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:e57739bf261dfcdaec492632f1986b57c7d7bc45a4ba7be145beb64b739fe70f
 , ReplicaSetSpec =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:1bf2e546437454975e15c45e8d6e368fdb2ad72a4739cf0b6edbb2b859ed7395
+    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:1096f4abe714f3acf5de2068b8427a12bb8951c19a61235fc060bd39fbb8f3ba
 , ReplicaSetStatus =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , RollingUpdateDaemonSet =
@@ -61,7 +61,7 @@
 , RollingUpdateStatefulSetStrategy =
     ./defaults/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:4d9feb8034f9f58692aebeed06474c07c387e5b8bc11c40dc36ec6390a26fa63
 , StatefulSet =
-    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:eb4db7ba9a51c6a246cdf9bca1fdf6f240a5d5e9f7d8c452657d296a7bed2e1b
+    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:cf3e3e9bda1894fa53f6042877fd8472fcd6bbaf1798fa312ad15a973fc33957
 , StatefulSetCondition =
     ./defaults/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , StatefulSetList =
@@ -161,7 +161,7 @@
 , ResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Job =
-    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:2cd50fe822a09f781355d82aaad71d130c6311f803ff5fc22d9ddfaeb0fe212d
+    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:9e47987f553f9dcc70482593690b6c19ced50bc58c997c634d109383e5b89a0e
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
 , JobList =
@@ -171,7 +171,7 @@
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall sha256:acf4f792ff1e56e53cb6d00ddc60f6ade85c44289efcbbfd2e5b81e1ac0347fc
 , CronJob =
-    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:219fcc24777493296b9f04a823cd0ccd4c7c46f97ee7e9b50f6c3fbde23df966
+    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:db0bb0ecb2a3247441a2e5bbd6a49cd0db4f40d99896ce2d6f2e5278e090b1ac
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:d6f792b6d1f5cc8e862708490973d8b46eeb2d7adf4f3be3170a93ce2b70be7a
 , CronJobSpec =
@@ -179,7 +179,7 @@
 , CronJobStatus =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:751a6c74f8753d8467f43f76bc3b0661655a65daf9f907f6f814f01ade0fcd70
 , JobTemplateSpec =
-    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:090e406f76745cf85d628ecca6159f289e5d46b33ed83a0697162831dc8865c4
+    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:b581d1ba3eee41b9247198154ccbbf4b2a6c69f13c27a69c703c29e36725aae2
 , CertificateSigningRequest =
     ./defaults/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:fc1ae5e4b43cbc3d6410fce82d6859e180c77ce5b9c643b2562588f85e1ab780
 , CertificateSigningRequestCondition =
@@ -435,11 +435,11 @@
 , PodStatus =
     ./defaults/io.k8s.api.core.v1.PodStatus.dhall sha256:bfe78f7e337e9b29e89d26cb8e8a0cf9565e1fae36a61f0623f53d44f5dfcb4f
 , PodTemplate =
-    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:aeb73d484e21b839c19ee09d8ba9db103e31e2fdbc6175461920a2ccd3442da4
+    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:880f17f863f3c6f0cd5434f0fbc84ffa8e1f538ad32b7f36b3e6ec459d137789
 , PodTemplateList =
     ./defaults/io.k8s.api.core.v1.PodTemplateList.dhall sha256:51ca93c255c7ab48ec42245f8b34a4effdd072cd019931f37ef304d8b46d6e6f
 , PodTemplateSpec =
-    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:d51e15bdb9cec4307890f4658afa21d4bea5da7d24ef2acd427253a8453ddb78
+    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:6500c8c6019e68190a2ee6241f39b624cbf0f8d523261b63ab6d50fcedbd69e3
 , PortworxVolumeSource =
     ./defaults/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:5d8e73366d928941a81088f57aaf538a8c3a8d171086228dcefe3aa8084e6a0a
 , PreferredSchedulingTerm =
@@ -455,13 +455,13 @@
 , RBDVolumeSource =
     ./defaults/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:0c1b0c6ed400fe9c63c9a97d77d6d6a69463137e0e43687c4087b7e8cce747c3
 , ReplicationController =
-    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:8d66c75de69451f3d2e0751a44216e44eb75c73f8e9267a0dbb0d8f11acc09cd
+    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:af355609de3cd9ada7c468f40d83f20fa3895f766db4789a4f800f59d883f1db
 , ReplicationControllerCondition =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicationControllerList =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:e7dcae86af1b284f62a6f26fe1e432a6a27a9fa5c3100acdad84794ac21ed769
 , ReplicationControllerSpec =
-    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:70e8b6d7f9d304e3695a862de6bcf686243b7e03f83187023b0a230f447756a3
+    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:68ac2a8192ffbc26796c664c04c00461251aa7bbdbd18e9175a28f24d67ea1bd
 , ReplicationControllerStatus =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , ResourceFieldSelector =

--- a/1.13/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.13/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.13/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.13/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.13/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.13/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall
+}

--- a/1.13/package.dhall
+++ b/1.13/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:bb697acb947b1bcf961fb0e33be1eef835b3a402a37b95ee63bc2c3486eb1cfa
+  ./schemas.dhall sha256:4c6f7a6b1cbea0274fc659e040a2acdaac2efd809b3988d854fbab1053582117
 ∧ { IntOrString =
-      ( ./types.dhall sha256:29c592c05af44a06ae19915bb14ab8b1965b5e63b93e84aea6d2a9e9d44da99d
+      ( ./types.dhall sha256:64eaacd4a760eb484d7bc2d1ada20cd7227db980c582fdd5f3c5639a8a2d45c2
       ).IntOrString
   , Resource =
-      ./typesUnion.dhall sha256:6774bfec1d12d0e61ab18b609820e5a352e7500d95d59d971096241a197001dc
+      ./typesUnion.dhall sha256:cf22177ab9eddf43dd72db23ebe069eb41c1fd83a9dd4ef637a4324df7fff7b4
   }

--- a/1.13/schemas.dhall
+++ b/1.13/schemas.dhall
@@ -21,37 +21,37 @@
 , ControllerRevisionList =
     ./schemas/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:60bccd5a71d411feffc31aba6f4ec3c61f0ceee9c624cd8a024c7e0fe4d3ba27
 , DaemonSet =
-    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:8eb710f6e4ac89e0252dff41e66059521858a285ae4fde9bbb62faedcc6cc23c
+    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:d1b1f824f3634bf03d2866bb83c53308551f46436f51d8ecc52897aa76aa7985
 , DaemonSetCondition =
     ./schemas/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , DaemonSetList =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:3a1a9f4b2532dd01bb0a5d49c0bbf099b60587a16e482aab2a5a25590a2b29ca
+    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:a53121e89091884b96011a9a40cb15dd08ff4d3f6e2e0db3fb71f93d19948664
 , DaemonSetSpec =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:9281d8752a911793768ecae316067d1c1f60b71a578290c4f2ce98c6dfcd64b7
+    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:8343aa8c307b5716e1ed28f72921510c3c6c6f879d73e2bad6b2b7daf992b317
 , DaemonSetStatus =
     ./schemas/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:a68e46f267e6a5071080338953f8b1d13dff20cbfc06ae4b25f7645ff0b6cff6
 , DaemonSetUpdateStrategy =
     ./schemas/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:3efad19fff60b45006bb76c1bb6bd872e33a62d006dc6c6cd699c5945342814a
 , Deployment =
-    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:39ef1e42c261f340b2cde205a719ffa32d4e58768a0011fc6d3cd38943ad562c
+    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:217d65654e068bc4d2c84bd6808f295db5fb7dd09543dff2dc48ef8d8c66f811
 , DeploymentCondition =
     ./schemas/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:f6d653c489ad36f5ef1c422a5a8297e7e73b95210cc0e4224611c6188bad3fd5
 , DeploymentList =
-    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:175a9271093fdcea797abe68c312e3f88b5801c9cee8f4ab88155dd581a27771
+    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:d843c41f0e0bae569dac931bf28b519c67be8c902a1dcd658d3eb97d11d73c49
 , DeploymentSpec =
-    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:3ff39431cde1927af768b869b1ead47b2bd9906b5aaffc0a80623feda63ce76a
+    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:dc2b29dbf8bd0d81d1dd70b3d4f1f2d0cca97fc72ed0e897311fcb72e63dcf95
 , DeploymentStatus =
     ./schemas/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:6c1a6f0ab5f98b0ae2aa9d861ea0ede60adbf94b1e21f0e2be39d6abe21bda39
 , DeploymentStrategy =
     ./schemas/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:f6893d857d85ff5bf089070c9a3416026483331e40c3999c52dc17d9a06bdecd
 , ReplicaSet =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:209232dc9453036b8a9f945b0b7b099280125346385ce4479af2375c05a55ed8
+    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:20ae7d69988b83744fba52c8f750f8dea59b9e0fc67056d73058e35dc2faf834
 , ReplicaSetCondition =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicaSetList =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:c598e6af1a0c1cab895959aea8b0125bf51d57eb68b78d5ca43f98e95795b480
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:445c56efc1632af92f9edfb4c04c6678aa7b1fdd6bc99315781212b5a0973976
 , ReplicaSetSpec =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:dd4a54254955525d8daf68b495b8324ddef2be9ded7427f5bc1596e6a8a9578b
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:0f38eac320fef070659fec8e9414310aa689051f8bcdb7561432f3334e76ecdb
 , ReplicaSetStatus =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , RollingUpdateDaemonSet =
@@ -61,13 +61,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./schemas/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:0471cec7aab65313bb60ff3f774ee8d8c8e406f16b34f3dd27b50659055acecb
 , StatefulSet =
-    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:aa34886223bed983a487af942f1db0b87327d3ee51a78f7da9b3d0ffa9db7f2f
+    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:c5d7bca9ab61ec211a23aedb321e7b72c77044c3662c520873e73205b7776391
 , StatefulSetCondition =
     ./schemas/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , StatefulSetList =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:9c9b5e00126780df8f224ae507658afea3701cd3a0b20dd419ebc263903dfef6
+    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:27e6ceea8d9801178a98622c6da1c2d05c09e26c17e154056126d6abeae2e24a
 , StatefulSetSpec =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:08d011ad58e9a360edbb3bea621cdb5481a916823140c41b804419809a571fd7
+    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:aecf430b6b3efc8eb9ac5201994cfe1d39b28a66f3b8e8a9d974c5b8a91adcbd
 , StatefulSetStatus =
     ./schemas/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:a490d193b72e53cbb9b1fe35dde9bc02415e3f01bf8ce8a516ddbad25855df42
 , StatefulSetUpdateStrategy =
@@ -161,25 +161,25 @@
 , ResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , Job =
-    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:f7569c9f0c786208c1f20b8744f7b1463e45de8ca0ce6ecd317bc7f25c7667f3
+    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:c6b3326e79c60855464b99ade2fc778a149831933e89b929aa93062f594bbd94
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
-    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:66254f8d59ecd4945e27aeec8305559ab4b76990745c9fa3987bf489d9d5f709
+    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:3c94cdfa7665df13a2673298e659a8f36041f984c79e302efa66bb36c5284483
 , JobSpec =
-    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:63dda328c4fec281c2587927d0c2283b43b27b3334197d8cf35bad32cb3155af
+    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:db6999b3ee938c10df9dea7cd95ddfe5464149f41818c3ca39ef8bd5fd6c10bc
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall sha256:ddbf73e9d4be060bdfb9aabc84c1ad30860a6ac6b37fcdbff7bbae8e473a33c1
 , CronJob =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:32671149a40cba24faa441f4da4586fd506f93d337832f33be30ac8c216261d5
+    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:8d89ecbe966079c2d163b33e08e631d627aff26fb30106b417144f4adc9f90a0
 , CronJobList =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:a75bd5e2b47247b2eb019e2fa61ef15ff9abbeb48ac880de5da7c685fef92316
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:43f31a0c87b3860daa62961eb51351e6cf44d47d28184dab4b95b3a5b49c72aa
 , CronJobSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:3c03ef5c6b8af302b3a327db372b525722c9967d45752e127e8094338f53611b
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:207829264f6503a50a9a73c9ad50a07cf36505f95ad29d3619cd11d28f610f13
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:aaef515cade329c5c1bccb54d90e32c20c3b7bcb96ffdee38650292cf56c10d4
 , JobTemplateSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:145c8c17fd1358c90c2d70595f357cc2468c83c772cbea2d7ae64ecf7c1abca3
+    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:be4d626b7e711f3e404834ecce21b3b82a290995537b595a6fa6a178284d6689
 , CertificateSigningRequest =
     ./schemas/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:aaec32ab8e6b2b4ea66b21fe57cc534feb71cc82a60446369a13e15768610a7b
 , CertificateSigningRequestCondition =
@@ -435,11 +435,11 @@
 , PodStatus =
     ./schemas/io.k8s.api.core.v1.PodStatus.dhall sha256:3f3b362bc1cce319352f71c211fe1e0540c74783ca52dc284b1dd81fde5dba59
 , PodTemplate =
-    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:6a0b7fb47fbc6a3bd969554216d37e31391ff745535dd520bcbe21292be8f574
+    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:9731643f25f637ffc8dcf56150f88cbdaba63a09ef9bb9a306ecd32f01e6717e
 , PodTemplateList =
-    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:f13d3a79866d74d62e9ebeb874606e9b05067313e2d373df878856e1fa89bed1
+    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:29228cc84096918b2c505e5fdb87eac8e597546319c84e6bf76c24926f1558c5
 , PodTemplateSpec =
-    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:eb7a5818a6adcc297a33f3534443fb4c0a4cea92f5c49660392abb46ce887976
+    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:a2b42c358568a995b98a5de73d0f2d2c80d122ac43569d5203c184134f27c3ed
 , PortworxVolumeSource =
     ./schemas/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:b0bf02de5706c9f17b2dfb7f5938941151708cffc2bf1e4c69ca4a9ed1e4b735
 , PreferredSchedulingTerm =
@@ -455,13 +455,13 @@
 , RBDVolumeSource =
     ./schemas/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:ac07443af1c9f57e0175d9468507c2259feee9ea807f71ba4f5383658d62cd36
 , ReplicationController =
-    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:95700978e70fbf10e7e67e7d57e119b3c030bedc0346aff096184b67a3f97af6
+    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:0bf7236ea3f7e36f406c94e9c2e9e1f65bf2686b678c28b90c1757599d620760
 , ReplicationControllerCondition =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicationControllerList =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:8457987ec8ab11687386e5fcbd459ac3b6f00c6608b3477639aaed95f0056973
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:44a9747e449fdae94bd836933feb48b041e5e4efd06ee7996304cb0653d32c62
 , ReplicationControllerSpec =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:4a7af599f2e0cf2f8c745c9db0b2b5205e1c29d2db0c66da8a4eb2ad9954ae1f
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:206fd7b5ed9de887384771e803b9a615df683781ef14c5512d2efcb2afc2bee1
 , ReplicationControllerStatus =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , ResourceFieldSelector =

--- a/1.13/types.dhall
+++ b/1.13/types.dhall
@@ -21,37 +21,37 @@
 , ControllerRevisionList =
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:741a3888ecced1bbd85b27a289cac3fd393866f1a488a036676b942190d11215
 , DaemonSet =
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:062e3dd76e230280db00fb21aeae5cd1de240da41557a5d08d729b210d3e72e3
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:0268866b0a65fc5a06ff064abc1154b1c46ea0af74414b6a47a0e45507c44408
 , DaemonSetCondition =
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , DaemonSetList =
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:a2860f65cbf6a920fb80227ef75201e05564436ad701566a121990e1644401d4
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:bd277d40e40b4455a50be6cf140682b4c1e7b4857d6b2cfa331f4833f9d018ed
 , DaemonSetSpec =
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:7416efc295667f27c726f4bb9a69432b511c0e38427501482d8c098eb3a53047
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:c554ae4f4134662749458ec71b16bc35fa574c190782c73c8cc6a942b61a313d
 , DaemonSetStatus =
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 , DaemonSetUpdateStrategy =
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 , Deployment =
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:2edcdeb1c2994c1b8a522de5aa1aa8e38989685c34cf32535c684699a3ae4715
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:c7e505fa34f27cc55d350ae9a09ef21c4a8e1d59ff11a962f6dd921f5a965ec6
 , DeploymentCondition =
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 , DeploymentList =
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:394b9f1e766b28a807764e1483790d47ff99388348ad563a3bdb6c91938c81c6
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:71d8d66edf1811a7e376b4d20f08d09e6bb0e551f7c8267e589ac698936b4642
 , DeploymentSpec =
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:5f635de37dc72c6cf7aaf71c4d6b824d2ea35e4e889c04e4301d24ddd982c386
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:91b97e8bcf5c8c7fee172a7cb755ac8f801a1bdea9ed81ae9d0efd5c35b4e9af
 , DeploymentStatus =
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 , DeploymentStrategy =
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 , ReplicaSet =
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:2f70f8198160bf42a9e38616c7ebb8b0d6d22e42d1ee0933ce37704318ea4563
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:600dc3c743f68283a96b568dbd21c1b7308aa5de9b8a99f85c6d2922c0e7c2af
 , ReplicaSetCondition =
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicaSetList =
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:6c56b19c4c7cb1fed38d1fb8cc1d6e1c0c5392d5cb6541b024c594e6e5615608
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:34bb1b0d7f3bffb4bf0839f97d8bd2e51fe37392384501b469c7fda6ab99fd4a
 , ReplicaSetSpec =
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:15c89952036b154319e9ed710cbaa1eeac54919eb123a68a2e3837f7a69474da
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:b3aee615af747d8f54fc62c9015d92b942cb8ee7c469b40993bce4aa2e7edff7
 , ReplicaSetStatus =
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , RollingUpdateDaemonSet =
@@ -61,13 +61,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 , StatefulSet =
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:b8f48b319a9301b608402adaa25eeeb66efb4f2ae7183e7acad018d2f1d7b026
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:9c0fb487ec18c062af88d65a796df405e4bdbf02aedd3d5a46c84a994a7e8641
 , StatefulSetCondition =
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , StatefulSetList =
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:7786a8802dece0ffd74f0286041683cdd0979f382b20bcb3f359a25408595c93
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:7c2bcf3d1cfc8cca268504622100334d34b0daa566fca079ae078d78bc54c8ff
 , StatefulSetSpec =
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:4c654f94aa484742d641b8a801efae1482368080925080f20f2245c845e1cde9
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:7d7542cbf7075cad71892d98fe4aa6bdd3d7a08bb85dffd3bef607d48567138d
 , StatefulSetStatus =
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 , StatefulSetUpdateStrategy =
@@ -161,25 +161,25 @@
 , ResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , Job =
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:c4a361131ce1d1150d936bacc1da520c596e6f4bdef3b4a9fadcc3ca14e68bcf
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:bc061561472254507f05f0359205ea1cdf7343767d76654e895029a7aaf12a78
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:c22df9110cb5d0342798a83d9e618b2f18d0a6c609e8187df0ec88665bce9475
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:61fd5728d6b2f035f97445cf19c4af70a1ac003372ad67e9cc28600a3a5dc109
 , JobSpec =
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:be81722ae86ae7d1ce877562b7dfd236117adf92d7f1a7a4a6aec22012ec2567
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:78e209cb68378226ff44a6fc6cb6f7f26b4303b316813a104be19074a926b7e8
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 , CronJob =
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:bc45a0d6288d89a97d38102c0957ba8164866c6dca4bb7694277ce29459b576b
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:756d19c9d0149de0c577cd7d09dc524a5c7ec746383a52b2666266e9dde3ccd3
 , CronJobList =
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:4cc6cdc3366eaeb134756852aab7d9b9c39ee32b8e2827cd884f69910f3206a8
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:6ccd33dbc04cc8279589ccabf3714fb531be40705aeeb415b5958923bc392f47
 , CronJobSpec =
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:11e638d66ed5b97b625a584ec20f7db077cf5523a780bec77c97790fbaa6db79
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:2bc95df37a177b150a72505085366d335156d247d68d985bae35203544450589
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 , JobTemplateSpec =
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:5b9f6414dd6f73a2a5a7365fe53d90cef7aca9c0f7937d3fdf6e4593a1370f26
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:a6afbc6e90cff88b61470f04d008b4d0481f390949be30a9e675c5b9bc514e4b
 , CertificateSigningRequest =
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:67dde39719f3f030cd948ea6bd21cf0d987b0799c03490c1e6d22600007f4259
 , CertificateSigningRequestCondition =
@@ -435,11 +435,11 @@
 , PodStatus =
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:391332987a601de8c7eb411e62d54495dd8231e7104c4e3f22043b6aea26319f
 , PodTemplate =
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:e4ee1a6bc453b8d7590a5376c31e2c748a8db4d573a32d8649f85bb96e0fb500
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:015207ead7c11201528acb1d0e2a6fde6dc9d6ae047f3514dce03ffc4116b005
 , PodTemplateList =
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:988276aa6c6d08ea8ac94765b47c1c43692768964334510954d738834ceabc3e
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:3865be17fa2d30601e64f488ee032d51cff70eac175b0d4c96d92ae1c006b771
 , PodTemplateSpec =
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:5d184e351ce4aa6f9f52104212840d30f871ee785ba0ed20ffeafab196d2ab23
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:a66295bf6baa2feecf7771691b92ff3e9efefc79495aa969e31936a871738fb4
 , PortworxVolumeSource =
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 , PreferredSchedulingTerm =
@@ -455,13 +455,13 @@
 , RBDVolumeSource =
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 , ReplicationController =
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:28c65938fa72d2074019f99cf40c86916b426f6015d47238db62628e353952ba
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:6d6ac8331011361d4419538401f3a2539ab1001ed376d11512aee13c81120638
 , ReplicationControllerCondition =
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicationControllerList =
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:408d68b6392fb50c6f1bd6bc3c3e83e81cf8474204fec5fde4e398c378ac51b0
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:60f410f275ca46ac560ef452f7ee7ed9d7f08defb67a63aac558f3d8c9ceeec5
 , ReplicationControllerSpec =
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:7098d8a1bfb22623c2c45a09c611dc38a32883862a6d2c5a920e0d47e40c80e5
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:f383506d007ce40a4d61f5ae9153150632bb4a5adc8b7931e38d8ca4a6fe4e51
 , ReplicationControllerStatus =
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , ResourceFieldSelector =

--- a/1.13/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.13/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.13/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.13/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.13/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.13/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.core.v1.PodSpec.dhall
 }

--- a/1.13/typesUnion.dhall
+++ b/1.13/typesUnion.dhall
@@ -21,37 +21,37 @@
 | ControllerRevisionList :
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:741a3888ecced1bbd85b27a289cac3fd393866f1a488a036676b942190d11215
 | DaemonSet :
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:062e3dd76e230280db00fb21aeae5cd1de240da41557a5d08d729b210d3e72e3
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:0268866b0a65fc5a06ff064abc1154b1c46ea0af74414b6a47a0e45507c44408
 | DaemonSetCondition :
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | DaemonSetList :
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:a2860f65cbf6a920fb80227ef75201e05564436ad701566a121990e1644401d4
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:bd277d40e40b4455a50be6cf140682b4c1e7b4857d6b2cfa331f4833f9d018ed
 | DaemonSetSpec :
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:7416efc295667f27c726f4bb9a69432b511c0e38427501482d8c098eb3a53047
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:c554ae4f4134662749458ec71b16bc35fa574c190782c73c8cc6a942b61a313d
 | DaemonSetStatus :
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 | DaemonSetUpdateStrategy :
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 | Deployment :
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:2edcdeb1c2994c1b8a522de5aa1aa8e38989685c34cf32535c684699a3ae4715
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:c7e505fa34f27cc55d350ae9a09ef21c4a8e1d59ff11a962f6dd921f5a965ec6
 | DeploymentCondition :
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 | DeploymentList :
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:394b9f1e766b28a807764e1483790d47ff99388348ad563a3bdb6c91938c81c6
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:71d8d66edf1811a7e376b4d20f08d09e6bb0e551f7c8267e589ac698936b4642
 | DeploymentSpec :
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:5f635de37dc72c6cf7aaf71c4d6b824d2ea35e4e889c04e4301d24ddd982c386
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:91b97e8bcf5c8c7fee172a7cb755ac8f801a1bdea9ed81ae9d0efd5c35b4e9af
 | DeploymentStatus :
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 | DeploymentStrategy :
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 | ReplicaSet :
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:2f70f8198160bf42a9e38616c7ebb8b0d6d22e42d1ee0933ce37704318ea4563
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:600dc3c743f68283a96b568dbd21c1b7308aa5de9b8a99f85c6d2922c0e7c2af
 | ReplicaSetCondition :
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicaSetList :
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:6c56b19c4c7cb1fed38d1fb8cc1d6e1c0c5392d5cb6541b024c594e6e5615608
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:34bb1b0d7f3bffb4bf0839f97d8bd2e51fe37392384501b469c7fda6ab99fd4a
 | ReplicaSetSpec :
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:15c89952036b154319e9ed710cbaa1eeac54919eb123a68a2e3837f7a69474da
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:b3aee615af747d8f54fc62c9015d92b942cb8ee7c469b40993bce4aa2e7edff7
 | ReplicaSetStatus :
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | RollingUpdateDaemonSet :
@@ -61,13 +61,13 @@
 | RollingUpdateStatefulSetStrategy :
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 | StatefulSet :
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:b8f48b319a9301b608402adaa25eeeb66efb4f2ae7183e7acad018d2f1d7b026
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:9c0fb487ec18c062af88d65a796df405e4bdbf02aedd3d5a46c84a994a7e8641
 | StatefulSetCondition :
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | StatefulSetList :
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:7786a8802dece0ffd74f0286041683cdd0979f382b20bcb3f359a25408595c93
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:7c2bcf3d1cfc8cca268504622100334d34b0daa566fca079ae078d78bc54c8ff
 | StatefulSetSpec :
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:4c654f94aa484742d641b8a801efae1482368080925080f20f2245c845e1cde9
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:7d7542cbf7075cad71892d98fe4aa6bdd3d7a08bb85dffd3bef607d48567138d
 | StatefulSetStatus :
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 | StatefulSetUpdateStrategy :
@@ -161,25 +161,25 @@
 | ResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | Job :
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:c4a361131ce1d1150d936bacc1da520c596e6f4bdef3b4a9fadcc3ca14e68bcf
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:bc061561472254507f05f0359205ea1cdf7343767d76654e895029a7aaf12a78
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:c22df9110cb5d0342798a83d9e618b2f18d0a6c609e8187df0ec88665bce9475
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:61fd5728d6b2f035f97445cf19c4af70a1ac003372ad67e9cc28600a3a5dc109
 | JobSpec :
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:be81722ae86ae7d1ce877562b7dfd236117adf92d7f1a7a4a6aec22012ec2567
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:78e209cb68378226ff44a6fc6cb6f7f26b4303b316813a104be19074a926b7e8
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 | CronJob :
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:bc45a0d6288d89a97d38102c0957ba8164866c6dca4bb7694277ce29459b576b
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:756d19c9d0149de0c577cd7d09dc524a5c7ec746383a52b2666266e9dde3ccd3
 | CronJobList :
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:4cc6cdc3366eaeb134756852aab7d9b9c39ee32b8e2827cd884f69910f3206a8
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:6ccd33dbc04cc8279589ccabf3714fb531be40705aeeb415b5958923bc392f47
 | CronJobSpec :
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:11e638d66ed5b97b625a584ec20f7db077cf5523a780bec77c97790fbaa6db79
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:2bc95df37a177b150a72505085366d335156d247d68d985bae35203544450589
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 | JobTemplateSpec :
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:5b9f6414dd6f73a2a5a7365fe53d90cef7aca9c0f7937d3fdf6e4593a1370f26
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:a6afbc6e90cff88b61470f04d008b4d0481f390949be30a9e675c5b9bc514e4b
 | CertificateSigningRequest :
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:67dde39719f3f030cd948ea6bd21cf0d987b0799c03490c1e6d22600007f4259
 | CertificateSigningRequestCondition :
@@ -435,11 +435,11 @@
 | PodStatus :
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:391332987a601de8c7eb411e62d54495dd8231e7104c4e3f22043b6aea26319f
 | PodTemplate :
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:e4ee1a6bc453b8d7590a5376c31e2c748a8db4d573a32d8649f85bb96e0fb500
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:015207ead7c11201528acb1d0e2a6fde6dc9d6ae047f3514dce03ffc4116b005
 | PodTemplateList :
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:988276aa6c6d08ea8ac94765b47c1c43692768964334510954d738834ceabc3e
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:3865be17fa2d30601e64f488ee032d51cff70eac175b0d4c96d92ae1c006b771
 | PodTemplateSpec :
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:5d184e351ce4aa6f9f52104212840d30f871ee785ba0ed20ffeafab196d2ab23
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:a66295bf6baa2feecf7771691b92ff3e9efefc79495aa969e31936a871738fb4
 | PortworxVolumeSource :
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 | PreferredSchedulingTerm :
@@ -455,13 +455,13 @@
 | RBDVolumeSource :
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 | ReplicationController :
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:28c65938fa72d2074019f99cf40c86916b426f6015d47238db62628e353952ba
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:6d6ac8331011361d4419538401f3a2539ab1001ed376d11512aee13c81120638
 | ReplicationControllerCondition :
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicationControllerList :
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:408d68b6392fb50c6f1bd6bc3c3e83e81cf8474204fec5fde4e398c378ac51b0
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:60f410f275ca46ac560ef452f7ee7ed9d7f08defb67a63aac558f3d8c9ceeec5
 | ReplicationControllerSpec :
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:7098d8a1bfb22623c2c45a09c611dc38a32883862a6d2c5a920e0d47e40c80e5
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:f383506d007ce40a4d61f5ae9153150632bb4a5adc8b7931e38d8ca4a6fe4e51
 | ReplicationControllerStatus :
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | ResourceFieldSelector :

--- a/1.14/defaults.dhall
+++ b/1.14/defaults.dhall
@@ -15,7 +15,7 @@
 , ControllerRevisionList =
     ./defaults/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:2343b690c1c4d49b5e1fe09da5a71fc9e8c74f2a9975764b0ad41cf597b6b616
 , DaemonSet =
-    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:3d8eb2a51b71121922f44a22fdf6a51fc7c9ba85f5e5b75188be19217dab08ed
+    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:d4caa903cd0dd2e6d29f002b2f4235b7b980d35a505e666cb760d09e0230d962
 , DaemonSetCondition =
     ./defaults/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , DaemonSetList =
@@ -27,7 +27,7 @@
 , DaemonSetUpdateStrategy =
     ./defaults/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:0267659f9e8647bbf2e9f9073536c4c0c60b8ff1c076523cd7773b05e8d1c270
 , Deployment =
-    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:a61c6c0a8bbf6cc5b5166c5634b3d5c7155b29b877b8ec47cc20b9ee011e4f2f
+    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:0c8a74c364055a698a9b36c65d18032b8f51c78d20d4a78d5e06b5e3dee3c19a
 , DeploymentCondition =
     ./defaults/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:006ebe956ae6e2918eb18beed3f6378d0f79437bfc449f4b6c7852206a7c7e5d
 , DeploymentList =
@@ -39,13 +39,13 @@
 , DeploymentStrategy =
     ./defaults/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:e5ba779274cb5a0b72069647e1aa8b257380ddb3b183aef45233028c399f65b9
 , ReplicaSet =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:8a94c60a9171a8c2a17fa9b11682ec930ba5071e5599c0cea453ed33ae0af136
+    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:310632e720336266650b2b93c2752f93cefaba6d9d348e5abd4f37909d86f7aa
 , ReplicaSetCondition =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicaSetList =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:e57739bf261dfcdaec492632f1986b57c7d7bc45a4ba7be145beb64b739fe70f
 , ReplicaSetSpec =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:9e0f5a026acbb52c9271deb6df5f55a01323ffec588665bcf42635089666429e
+    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:018bbbf0c2a03bc14b1dd9f1f89a05590c86b7558088506c387e832ca6ae558e
 , ReplicaSetStatus =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , RollingUpdateDaemonSet =
@@ -55,7 +55,7 @@
 , RollingUpdateStatefulSetStrategy =
     ./defaults/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:4d9feb8034f9f58692aebeed06474c07c387e5b8bc11c40dc36ec6390a26fa63
 , StatefulSet =
-    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:9983a7c1092367a2e0ba482e6e7c08b6572794a835e1d3812529e76842130206
+    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:536b6981f728bdb1f4f2b47f52f55deb948f82e1deb8c2416595ed8cb3c6def1
 , StatefulSetCondition =
     ./defaults/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , StatefulSetList =
@@ -155,7 +155,7 @@
 , ResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Job =
-    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:c4ab40b6fd454ea3ce95edca02fb88910807c567a34b75861c7eed71b07a73fc
+    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:c982e557432841ef7d938f04ee72d580c3e1fb7f558bf568d21fdebcca3f80fb
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
 , JobList =
@@ -165,7 +165,7 @@
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall sha256:acf4f792ff1e56e53cb6d00ddc60f6ade85c44289efcbbfd2e5b81e1ac0347fc
 , CronJob =
-    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:50171d4603b946be2d6680dbfd8f2a16f2a3f59cbf59ded5ea3f4250854a2d33
+    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:bde4a97434d9a37dcf59c9d1c7b54444b38fbf91e7939406596a812aa2172bb2
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:d6f792b6d1f5cc8e862708490973d8b46eeb2d7adf4f3be3170a93ce2b70be7a
 , CronJobSpec =
@@ -173,7 +173,7 @@
 , CronJobStatus =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:751a6c74f8753d8467f43f76bc3b0661655a65daf9f907f6f814f01ade0fcd70
 , JobTemplateSpec =
-    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:3d5887b26da2fe5cb320f50a4cfafd1d0f9f6c6aeb2cea2bec0f8fb58de9007c
+    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:bbcb981733af3ca614245185449724792ad265f50196ff2b16133a477ec5fa76
 , CertificateSigningRequest =
     ./defaults/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:fc1ae5e4b43cbc3d6410fce82d6859e180c77ce5b9c643b2562588f85e1ab780
 , CertificateSigningRequestCondition =
@@ -431,11 +431,11 @@
 , PodStatus =
     ./defaults/io.k8s.api.core.v1.PodStatus.dhall sha256:bfe78f7e337e9b29e89d26cb8e8a0cf9565e1fae36a61f0623f53d44f5dfcb4f
 , PodTemplate =
-    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:f911f247f42d280df08b689755b29c24d1eb65496f750354dac9919486c58c8c
+    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:470f6e11d7f8564605677f655e8e21702cb76e395820907adef62c3c4f1df78e
 , PodTemplateList =
     ./defaults/io.k8s.api.core.v1.PodTemplateList.dhall sha256:51ca93c255c7ab48ec42245f8b34a4effdd072cd019931f37ef304d8b46d6e6f
 , PodTemplateSpec =
-    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:d6cc249505856fba097325ae914e89010e01616456c32f4b9c9e21e59e9b4936
+    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:e2706a61e23196944dd9c17ef34f2158fc69a0f4b50535bb6e9d62a2895e0fd9
 , PortworxVolumeSource =
     ./defaults/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:5d8e73366d928941a81088f57aaf538a8c3a8d171086228dcefe3aa8084e6a0a
 , PreferredSchedulingTerm =
@@ -451,13 +451,13 @@
 , RBDVolumeSource =
     ./defaults/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:0c1b0c6ed400fe9c63c9a97d77d6d6a69463137e0e43687c4087b7e8cce747c3
 , ReplicationController =
-    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:f7f3f8aaf53d9aad3e2ab59a776113c400eb4c9e3fa2e7575989753392499490
+    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:7f7d0ed968801f2dd211167501c19b2a3eafbcb09204d25e0b0f532e3c6a4eda
 , ReplicationControllerCondition =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicationControllerList =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:e7dcae86af1b284f62a6f26fe1e432a6a27a9fa5c3100acdad84794ac21ed769
 , ReplicationControllerSpec =
-    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:8a75a1c6f3a19d83004cc0b158342fc484df9a09d174ed33baeea0ea09747680
+    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:8e6865415fd5d662b09f148fb9cefb9775d153177a6f95d2301c431f8f1f2b0b
 , ReplicationControllerStatus =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , ResourceFieldSelector =

--- a/1.14/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.14/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.14/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.14/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.14/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.14/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall
+}

--- a/1.14/package.dhall
+++ b/1.14/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:300080984aee7ec7f1073f22cd1b1775f200f2da0ecb346e2fba6e59d6883524
+  ./schemas.dhall sha256:2255b82e519931654c0c03202851919d5200b5faf7217dd1a6d5bc753a65a074
 ∧ { IntOrString =
-      ( ./types.dhall sha256:5900683b6f4275e9ce5b0815b3cacb1a6dae32cf234973a6bffc5ebc65f25f0d
+      ( ./types.dhall sha256:a4009f176469a2da0b4e7c47c7b7e8a0edf503475555b692760aeb2dd06fd126
       ).IntOrString
   , Resource =
-      ./typesUnion.dhall sha256:98c5b6e26e694721cc287366821715b85efaa74d28ec75f1a7d8745ff36f9a4f
+      ./typesUnion.dhall sha256:920a8e87eeadf270b69ffcb40caa35342416fa6a9317e6b27df186138874a282
   }

--- a/1.14/schemas.dhall
+++ b/1.14/schemas.dhall
@@ -15,37 +15,37 @@
 , ControllerRevisionList =
     ./schemas/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:e5083cb3d7f80af82e939842a533c19a0027546c8fb8ca11ff43854d09c3d52b
 , DaemonSet =
-    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:9ea0580e3e501cadeecb59ff8400416932a76273e59bf0cb48a5fb5aae641bfd
+    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:4ad08d266c1c378b9de9ae3fade91dcafe5ff1ce10436e7d55b6c603ede76946
 , DaemonSetCondition =
     ./schemas/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , DaemonSetList =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:24773317dfcd06f6f61da26e845b4c46a525e2e8d7124d3546c851831c606cc3
+    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:577b0a86dc719f49534946a9ca9a4144a7ac8438389f5970c9863ec468020df4
 , DaemonSetSpec =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:7863a725e040d5521586920342beecd8319d03cc376ad62e7847dd326d4f4dc7
+    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:e7897ab3051ec4ee3f0d08b384818dc322c1506223ddaef666127c5627e18eb9
 , DaemonSetStatus =
     ./schemas/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:a68e46f267e6a5071080338953f8b1d13dff20cbfc06ae4b25f7645ff0b6cff6
 , DaemonSetUpdateStrategy =
     ./schemas/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:3efad19fff60b45006bb76c1bb6bd872e33a62d006dc6c6cd699c5945342814a
 , Deployment =
-    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:2611a30d3c613643633eda967fe0a302f2d50541cf8495ea76eeb99f32cfbe0c
+    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:744bfa07f8ad5203f1200b7fd1261ffe144656db865bd40e5624579bec9d6ac6
 , DeploymentCondition =
     ./schemas/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:f6d653c489ad36f5ef1c422a5a8297e7e73b95210cc0e4224611c6188bad3fd5
 , DeploymentList =
-    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:752ba661337b972567eca868a4319a98a967a65b3217531e8a931f7b3585dee8
+    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:bc5520bf7bb36894aac16bc4fd2e24ed0c56c57d6993e09cd2c0e699968b70fe
 , DeploymentSpec =
-    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:30bdb4938c767072551478448b402159abb0e5de57b6b6506aa88197d4252a17
+    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:7ee71056c543a7cdb26dc2e1bdff4d4b849349708ca123b35a8d691669b37f6c
 , DeploymentStatus =
     ./schemas/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:6c1a6f0ab5f98b0ae2aa9d861ea0ede60adbf94b1e21f0e2be39d6abe21bda39
 , DeploymentStrategy =
     ./schemas/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:f6893d857d85ff5bf089070c9a3416026483331e40c3999c52dc17d9a06bdecd
 , ReplicaSet =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:f0b5750afd45c0c40e8a908afd39c26dcdaa771c0235a807ed87c08ca26a39e4
+    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:193a6884892595fd7e88276ec970357343e7c25d0a1a124770723e79ef8b8ffb
 , ReplicaSetCondition =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicaSetList =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:2bf3e2a3465af1830c5f54b22619bf94acc20af1fff5f6d9dbad017f52704aea
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:06147b54ab26ceb021e951527c8da108398b9214e933c1977e7b82ade20c525e
 , ReplicaSetSpec =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:7051dde5e5d451a701402c80c5ff7aa2542a888b08627fb6ce6f499384cbad8d
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:388eba1bbfde4b361c37199f6a8033cf80ead94a64a3610fc1bc4d23eae2981d
 , ReplicaSetStatus =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , RollingUpdateDaemonSet =
@@ -55,13 +55,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./schemas/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:0471cec7aab65313bb60ff3f774ee8d8c8e406f16b34f3dd27b50659055acecb
 , StatefulSet =
-    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:0f51370206cdaf1534f7a2be8a2ea57c8e8417c3798552ba1cb0b612207080e0
+    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:4d8e854343f92c634d05f3772b902809d313570ac89e1353fb27a3bf07866ddb
 , StatefulSetCondition =
     ./schemas/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , StatefulSetList =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:6dd11f95d8398fae44dddc6e49f754745991db88305db72bb344f05b22702faf
+    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:69a55cede525ca23881d8a61aaf0480dcd836f70f8e99dd5da72f52a7b583152
 , StatefulSetSpec =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:3974b48165780984ff5446b8b8cdb582c6b14919483376eb0c6d6aa0a652544a
+    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:ba5707b778e142f265122b771c27059c6f47ab617cc948aae4401c1718d5a72b
 , StatefulSetStatus =
     ./schemas/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:a490d193b72e53cbb9b1fe35dde9bc02415e3f01bf8ce8a516ddbad25855df42
 , StatefulSetUpdateStrategy =
@@ -155,25 +155,25 @@
 , ResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , Job =
-    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:a1d3961da8d2112e74b9389eca671a2af97a40f668cb48b9c2b695d3f392bf37
+    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:fdc399848580c344f5cfd8edad3a03fbdad804a077a2a346ba4606e86e0d2de8
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
-    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:3053613daf3027e3d58f41ee4d49482e3559623e852bda0b9b7274e236c952d1
+    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:1575a31cda05092c91c0216e5134005efc71d8d10112eb281578ac64a44922f6
 , JobSpec =
-    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:856bbea5b05e37ee7c4ee1cccfa1fab80eafff84563c016d08e20363db1b41bb
+    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:ccd614f788a77a774e69fd2dc2e5406f148ef4d94d0476cbc2aaf94266820f0d
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall sha256:ddbf73e9d4be060bdfb9aabc84c1ad30860a6ac6b37fcdbff7bbae8e473a33c1
 , CronJob =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:937a981c3cc1fb9b7405eb7aa539403859228bef9a651db8571d1f2a4eaca65d
+    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:aaec6bb41fd5254e73e399698c13f24c956438a3fc7b8d90e8d0cfcd27c97a99
 , CronJobList =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:be61a5de2a1c12f588c88ffa527def6978c17a595222f488fc900874b4300608
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:80219c7638078424d6481219d190ab58849f7179e1937ce06ff8a913a55e1300
 , CronJobSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:c0288f31b8b1c45c92171216aecfc1dc559b4f792ee5f909a823849cbabf6dc8
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:83a450fde62a4a0b7cd9856169d87b555a348e1a72d34b0d7936090adaa013fc
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:aaef515cade329c5c1bccb54d90e32c20c3b7bcb96ffdee38650292cf56c10d4
 , JobTemplateSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:7d59c52b9bf527f2cd4ebaa57f1ec7c64956104fd1b035dea2454778d7af1a87
+    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:fd18084647330a81569aaeb9e5ec583a1955b3e73a9090b68c68025f6ebc7086
 , CertificateSigningRequest =
     ./schemas/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:f3d16c44c810f3c4fb18f58713025d2722d0b1ec579c6e03fe64b5b25559a3db
 , CertificateSigningRequestCondition =
@@ -431,11 +431,11 @@
 , PodStatus =
     ./schemas/io.k8s.api.core.v1.PodStatus.dhall sha256:3f3b362bc1cce319352f71c211fe1e0540c74783ca52dc284b1dd81fde5dba59
 , PodTemplate =
-    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:d4c223f78ea01dc7c36b0e0800779cf5f2f1fed57205d0793c7ad927d4a86c3d
+    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:87ae7071435d4b3733c7483d88f527624edb74ced867253146faf4396be28dc4
 , PodTemplateList =
-    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:6aa906b26148014b5ff52eb89f68dde407c714806e055d28296e46dd733ebdbe
+    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:885e821ca064ed55a9c77c71c02aca7907d257ffd9a762e580f25331be677fd3
 , PodTemplateSpec =
-    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:804a5668fa578d55d4f26b1ea66715834834df0a8d198081f7654b8c9bd613a2
+    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:862298a0eadd7be42f57b6919f2fc9afbf67889ba3f01d26442f761a696fbd42
 , PortworxVolumeSource =
     ./schemas/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:b0bf02de5706c9f17b2dfb7f5938941151708cffc2bf1e4c69ca4a9ed1e4b735
 , PreferredSchedulingTerm =
@@ -451,13 +451,13 @@
 , RBDVolumeSource =
     ./schemas/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:ac07443af1c9f57e0175d9468507c2259feee9ea807f71ba4f5383658d62cd36
 , ReplicationController =
-    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:530d725b587c04d67708b33467293be3858101d078157aeaa4d028633859798e
+    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:275c7bfb15e2c82c2e64577439c6d17e74aa641d646b2465d32748eac9cfc6f2
 , ReplicationControllerCondition =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicationControllerList =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:5b6a5dd2f2f8bf7c8333723aa5c802e6a791dadfc307dd5db18d7dcd90097c07
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:6c9580987311681f1a1cb5f387e6af9c700770ca0145a2aa5425eafcd9749dca
 , ReplicationControllerSpec =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:b5fa54285faee40836737d6909f409aadb857d3d9ca1c4a3a840d0755c95193e
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:62614161c9a22e15fd987e84b2af21cbe1cee3a8dd61b85edc9b85c826ebe3e5
 , ReplicationControllerStatus =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , ResourceFieldSelector =

--- a/1.14/types.dhall
+++ b/1.14/types.dhall
@@ -15,37 +15,37 @@
 , ControllerRevisionList =
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:0d5c1beabaa6531630f608cd223838ef6049792593f1d28c7c58d162a6a4493d
 , DaemonSet =
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:5b9032ae5c85e46bd57503b5e9611610f3a28f0f925e42481116f012e7e1b1b4
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:149a14fdc4c2dac7dd27805ed912589cb3789fa2984e88430e0604b25a3beda8
 , DaemonSetCondition =
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , DaemonSetList =
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:5cee57453f514e456d08f6a419c13349a3324d33ee9ef02a6b093e5ebc2433dc
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:3bd6e0338c09db79c420b9ba91aa13105c78816817edefe2000535aab82b957a
 , DaemonSetSpec =
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:daf20b6e5f43b90f404f0d7f9ec4fb4d8109b92e94025e9c2af0ed63273fb50e
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:f680426a13687cd85c7fbce923454a45ca23f92f147f25d8a953bf40acfb0274
 , DaemonSetStatus =
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 , DaemonSetUpdateStrategy =
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 , Deployment =
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:9bbcd565581cfe571f42a84238a6a4f51da04719f981ac199ef5282d249133fe
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:2f614a77e53f3a42b46e6289833b8af1519f0e1ac3b2d44489c27897fca6425b
 , DeploymentCondition =
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 , DeploymentList =
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:6b5861bbed35e3ac1c164665fd88c80b3876fdfacd451571b768318e6190d394
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:7093644613e923c01d7973b75b28f3735d6409172b7fa27c31b1afbd672cd802
 , DeploymentSpec =
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:7133014f17f4c18e785db15fed4a635eda8d2e3602a24cfa813ef6e9c8aa9fa1
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:993ce86efe2d973bbe7270dd357b5aa80a1463c723a8474d9f5ade6e53cf4df0
 , DeploymentStatus =
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 , DeploymentStrategy =
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 , ReplicaSet =
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:3027e27663a3a5078ddb5637c2d0f8bd4edab5829b3f35e61a96486a432b251a
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:ca5daf16def45144b7c9e9ec744ce71961520b3ec61bce43f3cdeeffbeeaab64
 , ReplicaSetCondition =
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicaSetList =
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:0f6d58d3acb4ae2112d0d645a28e902cc750a5e110fd490d05aebeea2ecc6184
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:86876960032d32216fab85616aee3d16071cea75fb315dfe8b70e1b021c18cad
 , ReplicaSetSpec =
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:ed2a432d32bef3ed56ec0f6b9d22f2c4ce37e6dc599623530571e05f01d534cd
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:c0113a528be0c155553b89a87f7581a1d83ee39c477990218a6ef4848ccc2f76
 , ReplicaSetStatus =
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , RollingUpdateDaemonSet =
@@ -55,13 +55,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 , StatefulSet =
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:d07a6dad303e8e195d6760c06d59a9b0c0f27f83394d12a4243d8b49969ddd2b
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:5ad357eec3677c8e5831d3e2c8fba76084e0c594d74ef29df0d56855e24b4a8f
 , StatefulSetCondition =
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , StatefulSetList =
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:7113a1890784062ea3b508e8dfdd4fb26c0c762091b42ee411252ba3e5f23baa
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:00961a73313fa3e2dd6309818a5747ee4764f0b1d22576b7c230935f69888d8f
 , StatefulSetSpec =
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:6c86955b71859bdef84e0d7b4367c7d2cff0cec80ee8cb8801ac7f00c79f116c
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:a90fdba078b4fe60b793f592351d9ddeb2edd567c903760c3ad59d7a139b503f
 , StatefulSetStatus =
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 , StatefulSetUpdateStrategy =
@@ -155,25 +155,25 @@
 , ResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , Job =
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:e782323e0133d25c22ca25f45ba2ef6fe1a191acf8fdf3f58243ab89b49be946
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:afadebb4dc8f60f836fb4e64cd204672f87e36978af291c3e80ba67181efcf75
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:d23f23d41546377b42f7374906018ca38649f0b353d9fe55bd88e40d1bfa4259
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:4f15cad987bab9c916133db14e1cb16fffa23f88de73e1a665863bea2d00a5d9
 , JobSpec =
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:fca5de90cc69e974c5db0593507be637d7a2917180ab3c3af4abbaddfd64af91
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:e0a097525f865ecae3671032589cf764ac4db2f1ebd1b69875bb38cad27b10e0
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 , CronJob =
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:ce9090e1b44c8ec925241bd2f393c6f02e0a7f7c32d6599564800451cc58e5ec
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:b70ee6f53e445d35a361b9192671b9249d743562323842fb6da21385042b7073
 , CronJobList =
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:daaef243edb79509a31bdf7ff2af016f7a765f9af95039e9a4fdc0980bb7a3cf
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2daefc065598b9662cf617b9016e48f4277357adec2b73d4d9aaf92a30eb307a
 , CronJobSpec =
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:8af1c81f04b4bdcaa001b3bc12235f6da2b96cc8909891470c4d963cf5d6905c
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:2a0662dfe7d92eaa18379ec89362ed285b08bfc75e555d566ad196cfa1b93f89
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 , JobTemplateSpec =
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:3c36ea342281344b19675b558466ebd58b52ba7f10aa22323539151ff1a7f520
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:dff210109bd46bd57bafea4e70f2885d6dfec2bd64b25793397aa9a2c96cbdd2
 , CertificateSigningRequest =
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:a1935a892be0d391e579244a551a4105b9f5e79a9f9068c1b72cdbde3775d9ac
 , CertificateSigningRequestCondition =
@@ -431,11 +431,11 @@
 , PodStatus =
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:391332987a601de8c7eb411e62d54495dd8231e7104c4e3f22043b6aea26319f
 , PodTemplate =
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:5a0caf6c1b1dcc58e1963fe47bf69cc7207fbd01549e898f45b2f2350177a07e
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:2507b288d3c088ed452b1153cd3ae195e983de0d97a128458a5e954d2a3de2d4
 , PodTemplateList =
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:b6f3eead45ebee2860886ce18307049b7003da5b85a40e9a40dca034e7057afb
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:8d3b5a19dac99b05ca65116837b616d099c523899684cbb311305d2b4b949a51
 , PodTemplateSpec =
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:ddc6aba98b9680ccecff65c3b69b5baf5b765d940d6a262416fb1cf7dd59ccc4
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:f96f2c4e5d8f6a7492ee9eacf6475fe5b1ab376bc1b7ffe9b6b33b3b5fd81d0c
 , PortworxVolumeSource =
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 , PreferredSchedulingTerm =
@@ -451,13 +451,13 @@
 , RBDVolumeSource =
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 , ReplicationController =
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:dc06e8fc02276518e6b58bcb6523cc2d5ddb0bfccf94d82019db17e1fb03efea
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:966b2fa8f444f449cd35da38f16df0ff1aa203a6fc442be21a9753d368592c60
 , ReplicationControllerCondition =
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicationControllerList =
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:747d611c4b8d3dc84ab5caf8ebca2b20a5b08f2e85cf22ee484e9e3fe94084d2
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:eff3fde076de7f790a8a86f7287449628dbb6aa95449ba9a174b2a911e68cdfb
 , ReplicationControllerSpec =
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:f368fb78ec1186516442c50b74a0e677040e25f0059731354ce07b8a55005495
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:776a4cb13fba8f19199db708249a1ffaec0ae85f6d2a79f817c73ca45660ea48
 , ReplicationControllerStatus =
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , ResourceFieldSelector =

--- a/1.14/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.14/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.14/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.14/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.14/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.14/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.core.v1.PodSpec.dhall
 }

--- a/1.14/typesUnion.dhall
+++ b/1.14/typesUnion.dhall
@@ -15,37 +15,37 @@
 | ControllerRevisionList :
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:0d5c1beabaa6531630f608cd223838ef6049792593f1d28c7c58d162a6a4493d
 | DaemonSet :
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:5b9032ae5c85e46bd57503b5e9611610f3a28f0f925e42481116f012e7e1b1b4
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:149a14fdc4c2dac7dd27805ed912589cb3789fa2984e88430e0604b25a3beda8
 | DaemonSetCondition :
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | DaemonSetList :
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:5cee57453f514e456d08f6a419c13349a3324d33ee9ef02a6b093e5ebc2433dc
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:3bd6e0338c09db79c420b9ba91aa13105c78816817edefe2000535aab82b957a
 | DaemonSetSpec :
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:daf20b6e5f43b90f404f0d7f9ec4fb4d8109b92e94025e9c2af0ed63273fb50e
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:f680426a13687cd85c7fbce923454a45ca23f92f147f25d8a953bf40acfb0274
 | DaemonSetStatus :
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 | DaemonSetUpdateStrategy :
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 | Deployment :
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:9bbcd565581cfe571f42a84238a6a4f51da04719f981ac199ef5282d249133fe
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:2f614a77e53f3a42b46e6289833b8af1519f0e1ac3b2d44489c27897fca6425b
 | DeploymentCondition :
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 | DeploymentList :
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:6b5861bbed35e3ac1c164665fd88c80b3876fdfacd451571b768318e6190d394
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:7093644613e923c01d7973b75b28f3735d6409172b7fa27c31b1afbd672cd802
 | DeploymentSpec :
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:7133014f17f4c18e785db15fed4a635eda8d2e3602a24cfa813ef6e9c8aa9fa1
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:993ce86efe2d973bbe7270dd357b5aa80a1463c723a8474d9f5ade6e53cf4df0
 | DeploymentStatus :
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 | DeploymentStrategy :
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 | ReplicaSet :
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:3027e27663a3a5078ddb5637c2d0f8bd4edab5829b3f35e61a96486a432b251a
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:ca5daf16def45144b7c9e9ec744ce71961520b3ec61bce43f3cdeeffbeeaab64
 | ReplicaSetCondition :
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicaSetList :
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:0f6d58d3acb4ae2112d0d645a28e902cc750a5e110fd490d05aebeea2ecc6184
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:86876960032d32216fab85616aee3d16071cea75fb315dfe8b70e1b021c18cad
 | ReplicaSetSpec :
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:ed2a432d32bef3ed56ec0f6b9d22f2c4ce37e6dc599623530571e05f01d534cd
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:c0113a528be0c155553b89a87f7581a1d83ee39c477990218a6ef4848ccc2f76
 | ReplicaSetStatus :
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | RollingUpdateDaemonSet :
@@ -55,13 +55,13 @@
 | RollingUpdateStatefulSetStrategy :
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 | StatefulSet :
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:d07a6dad303e8e195d6760c06d59a9b0c0f27f83394d12a4243d8b49969ddd2b
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:5ad357eec3677c8e5831d3e2c8fba76084e0c594d74ef29df0d56855e24b4a8f
 | StatefulSetCondition :
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | StatefulSetList :
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:7113a1890784062ea3b508e8dfdd4fb26c0c762091b42ee411252ba3e5f23baa
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:00961a73313fa3e2dd6309818a5747ee4764f0b1d22576b7c230935f69888d8f
 | StatefulSetSpec :
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:6c86955b71859bdef84e0d7b4367c7d2cff0cec80ee8cb8801ac7f00c79f116c
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:a90fdba078b4fe60b793f592351d9ddeb2edd567c903760c3ad59d7a139b503f
 | StatefulSetStatus :
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 | StatefulSetUpdateStrategy :
@@ -155,25 +155,25 @@
 | ResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | Job :
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:e782323e0133d25c22ca25f45ba2ef6fe1a191acf8fdf3f58243ab89b49be946
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:afadebb4dc8f60f836fb4e64cd204672f87e36978af291c3e80ba67181efcf75
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:d23f23d41546377b42f7374906018ca38649f0b353d9fe55bd88e40d1bfa4259
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:4f15cad987bab9c916133db14e1cb16fffa23f88de73e1a665863bea2d00a5d9
 | JobSpec :
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:fca5de90cc69e974c5db0593507be637d7a2917180ab3c3af4abbaddfd64af91
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:e0a097525f865ecae3671032589cf764ac4db2f1ebd1b69875bb38cad27b10e0
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 | CronJob :
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:ce9090e1b44c8ec925241bd2f393c6f02e0a7f7c32d6599564800451cc58e5ec
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:b70ee6f53e445d35a361b9192671b9249d743562323842fb6da21385042b7073
 | CronJobList :
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:daaef243edb79509a31bdf7ff2af016f7a765f9af95039e9a4fdc0980bb7a3cf
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2daefc065598b9662cf617b9016e48f4277357adec2b73d4d9aaf92a30eb307a
 | CronJobSpec :
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:8af1c81f04b4bdcaa001b3bc12235f6da2b96cc8909891470c4d963cf5d6905c
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:2a0662dfe7d92eaa18379ec89362ed285b08bfc75e555d566ad196cfa1b93f89
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 | JobTemplateSpec :
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:3c36ea342281344b19675b558466ebd58b52ba7f10aa22323539151ff1a7f520
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:dff210109bd46bd57bafea4e70f2885d6dfec2bd64b25793397aa9a2c96cbdd2
 | CertificateSigningRequest :
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:a1935a892be0d391e579244a551a4105b9f5e79a9f9068c1b72cdbde3775d9ac
 | CertificateSigningRequestCondition :
@@ -431,11 +431,11 @@
 | PodStatus :
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:391332987a601de8c7eb411e62d54495dd8231e7104c4e3f22043b6aea26319f
 | PodTemplate :
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:5a0caf6c1b1dcc58e1963fe47bf69cc7207fbd01549e898f45b2f2350177a07e
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:2507b288d3c088ed452b1153cd3ae195e983de0d97a128458a5e954d2a3de2d4
 | PodTemplateList :
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:b6f3eead45ebee2860886ce18307049b7003da5b85a40e9a40dca034e7057afb
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:8d3b5a19dac99b05ca65116837b616d099c523899684cbb311305d2b4b949a51
 | PodTemplateSpec :
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:ddc6aba98b9680ccecff65c3b69b5baf5b765d940d6a262416fb1cf7dd59ccc4
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:f96f2c4e5d8f6a7492ee9eacf6475fe5b1ab376bc1b7ffe9b6b33b3b5fd81d0c
 | PortworxVolumeSource :
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 | PreferredSchedulingTerm :
@@ -451,13 +451,13 @@
 | RBDVolumeSource :
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 | ReplicationController :
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:dc06e8fc02276518e6b58bcb6523cc2d5ddb0bfccf94d82019db17e1fb03efea
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:966b2fa8f444f449cd35da38f16df0ff1aa203a6fc442be21a9753d368592c60
 | ReplicationControllerCondition :
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicationControllerList :
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:747d611c4b8d3dc84ab5caf8ebca2b20a5b08f2e85cf22ee484e9e3fe94084d2
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:eff3fde076de7f790a8a86f7287449628dbb6aa95449ba9a174b2a911e68cdfb
 | ReplicationControllerSpec :
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:f368fb78ec1186516442c50b74a0e677040e25f0059731354ce07b8a55005495
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:776a4cb13fba8f19199db708249a1ffaec0ae85f6d2a79f817c73ca45660ea48
 | ReplicationControllerStatus :
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | ResourceFieldSelector :

--- a/1.15/defaults.dhall
+++ b/1.15/defaults.dhall
@@ -17,7 +17,7 @@
 , ControllerRevisionList =
     ./defaults/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:2343b690c1c4d49b5e1fe09da5a71fc9e8c74f2a9975764b0ad41cf597b6b616
 , DaemonSet =
-    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:7e8e114e060583aec3413a7f307325b1be33cc3aa5c33417e20e076323506f09
+    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:1836a77fb2891ab2aa280003b47fb4c766f4265634c13f604e01ee481777c384
 , DaemonSetCondition =
     ./defaults/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , DaemonSetList =
@@ -29,7 +29,7 @@
 , DaemonSetUpdateStrategy =
     ./defaults/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:0267659f9e8647bbf2e9f9073536c4c0c60b8ff1c076523cd7773b05e8d1c270
 , Deployment =
-    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:902287221b92b4fd569bc61f0736c9fdedd0c58ddf754b7218997f7ecfcc1aa9
+    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:c8aa1e471e199d8a082c9da197921bfc1adf30a4333564007cbacca242a1be5a
 , DeploymentCondition =
     ./defaults/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:006ebe956ae6e2918eb18beed3f6378d0f79437bfc449f4b6c7852206a7c7e5d
 , DeploymentList =
@@ -41,13 +41,13 @@
 , DeploymentStrategy =
     ./defaults/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:e5ba779274cb5a0b72069647e1aa8b257380ddb3b183aef45233028c399f65b9
 , ReplicaSet =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:34032e1090fa9f641ece7b7f62a30ce77fbd12bc95073e978526b47b911060c3
+    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:f6a969c756b2590a2415a6cf7451e05478cee4bb0555fb150d4af6b430823f93
 , ReplicaSetCondition =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicaSetList =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:e57739bf261dfcdaec492632f1986b57c7d7bc45a4ba7be145beb64b739fe70f
 , ReplicaSetSpec =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:34135e31d9db176e90320355b742b1c98430c63b9f3912595830ffba4a794e79
+    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:f035c1903c65fdae8199463ecb953c4183cbe6a3e94b5304ef9e3f0373e81c4c
 , ReplicaSetStatus =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , RollingUpdateDaemonSet =
@@ -57,7 +57,7 @@
 , RollingUpdateStatefulSetStrategy =
     ./defaults/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:4d9feb8034f9f58692aebeed06474c07c387e5b8bc11c40dc36ec6390a26fa63
 , StatefulSet =
-    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:8bf887040117ba9badf88e1bf19937b91b2ea01cc37304705ee361d0f935b299
+    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:0b6d02028b2cc72706f9afc6f9a089c65ee9563b67daeb3a56d3f13c4c11c998
 , StatefulSetCondition =
     ./defaults/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , StatefulSetList =
@@ -159,7 +159,7 @@
 , ResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Job =
-    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:ae81abffcda6ea392da488998e16c008fdd69fdbc9ab236727aaf21208cf3cd6
+    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:69fa5241b4b0126d2d3c5c607ac9f3f8193ec520baffa4425d358dbc33ec0a9e
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
 , JobList =
@@ -169,7 +169,7 @@
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall sha256:acf4f792ff1e56e53cb6d00ddc60f6ade85c44289efcbbfd2e5b81e1ac0347fc
 , CronJob =
-    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:6e6340373f86eb61a2bb66ecc57457ea795f027cfc2b55720dc9ebe4dfef0f4c
+    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:5c6605780fdd8865a179355f13856ef02c6cfa02248f4a9a127ea4c65c1d1509
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:d6f792b6d1f5cc8e862708490973d8b46eeb2d7adf4f3be3170a93ce2b70be7a
 , CronJobSpec =
@@ -177,7 +177,7 @@
 , CronJobStatus =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:751a6c74f8753d8467f43f76bc3b0661655a65daf9f907f6f814f01ade0fcd70
 , JobTemplateSpec =
-    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:efef629752ed03765b199b69bc304b10f60c7e07554256c922a3954a9b6eb065
+    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:bf8880e2eb06a26e52f626426679af5a8591c26ad8869e483081bed88657bf9e
 , CertificateSigningRequest =
     ./defaults/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:fc1ae5e4b43cbc3d6410fce82d6859e180c77ce5b9c643b2562588f85e1ab780
 , CertificateSigningRequestCondition =
@@ -435,11 +435,11 @@
 , PodStatus =
     ./defaults/io.k8s.api.core.v1.PodStatus.dhall sha256:bfe78f7e337e9b29e89d26cb8e8a0cf9565e1fae36a61f0623f53d44f5dfcb4f
 , PodTemplate =
-    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:d36c01798c37edba927ca7f7aca4b271e57af1dcc56029bc15d71bbbca62bee5
+    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:e996cab4a75e3d34d37fab0eb185e3c47598368eab22b4ecee6639e4d30ef785
 , PodTemplateList =
     ./defaults/io.k8s.api.core.v1.PodTemplateList.dhall sha256:51ca93c255c7ab48ec42245f8b34a4effdd072cd019931f37ef304d8b46d6e6f
 , PodTemplateSpec =
-    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:ffc6070fe1fff82d6911df8a0e9ef560e9875c7ab37c04d8cf76de21facfaefe
+    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:1e165c982b5c443b03642fc83aa9051276a34b49f7ebcee7e5eb2757d49fcf69
 , PortworxVolumeSource =
     ./defaults/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:5d8e73366d928941a81088f57aaf538a8c3a8d171086228dcefe3aa8084e6a0a
 , PreferredSchedulingTerm =
@@ -455,13 +455,13 @@
 , RBDVolumeSource =
     ./defaults/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:0c1b0c6ed400fe9c63c9a97d77d6d6a69463137e0e43687c4087b7e8cce747c3
 , ReplicationController =
-    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:d6c49632e2cb828186cf4a3d5ee03326e742d5a24b0ca920a492fa21a6d7c127
+    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:59e8149809beb5c3537d6dfc1d945f23d3ff190cae010172c3ffc5b286522dd8
 , ReplicationControllerCondition =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicationControllerList =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:e7dcae86af1b284f62a6f26fe1e432a6a27a9fa5c3100acdad84794ac21ed769
 , ReplicationControllerSpec =
-    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:be0b7ee1e7e50141d27a932627781ba5c04e5499d6804e29572f72e7c9c0b718
+    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:4375914c32ec6b81effd1b69fdf59a4cf83de9254c1580f5c3123cc36163f83c
 , ReplicationControllerStatus =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , ResourceFieldSelector =

--- a/1.15/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.15/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.15/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.15/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.15/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.15/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall
+}

--- a/1.15/package.dhall
+++ b/1.15/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:5b533a7fb3e7e64a8b660200a603b2d0f9552f3e028479e14a7454d5ea6b7a05
+  ./schemas.dhall sha256:1fd3daeb93f85a205df8c645d31ea0127fff328f7c86bf862d74911ae7c9da66
 ∧ { IntOrString =
-      ( ./types.dhall sha256:b1d4ee60fa7cabcc22bef1c2ac730e0343583659d70b2d57a490a121a2360253
+      ( ./types.dhall sha256:e45b982e07a5fc2b5595332b559ef272a1f6e03f8f8e2e75b98ef420db85cc4f
       ).IntOrString
   , Resource =
-      ./typesUnion.dhall sha256:dc2469876e467ce175af02b1a9a7ef9948a82bece1e83216d8ab9a33b80f8da2
+      ./typesUnion.dhall sha256:a0afca3017673a40e053fc9b1ad6c186db0b81051b609aef6fdee9078de4a4a1
   }

--- a/1.15/schemas.dhall
+++ b/1.15/schemas.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./schemas/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:197316dd076db97489f7ef24f0b3a557cf874180d37175d5a2d95a162df52c3e
 , DaemonSet =
-    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:ba7f41bc89121d3d4e426cfecaf2cb15de6c3b8e3ace1477d68c87bac2a653ba
+    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:cf96a8140f63dbefb1ba22c651bdfe57356912ea251dde1c4378215a6de89033
 , DaemonSetCondition =
     ./schemas/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , DaemonSetList =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:c7e78318f761eb241be33b257a78fae0ef125c99b374b3249d4aaaa5a9e1810a
+    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:48dd13d1705850938de3000c28db829498b8c74bd8cdf17dbfc942319e531bd9
 , DaemonSetSpec =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:6d1947396377e2597b698650509f7691b59a27c073ee053f768dcf5bfbe81839
+    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:f006b3e1e8bc08d86444ecca304872e1c215e9e041dc553bae545e7680adf67f
 , DaemonSetStatus =
     ./schemas/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:a68e46f267e6a5071080338953f8b1d13dff20cbfc06ae4b25f7645ff0b6cff6
 , DaemonSetUpdateStrategy =
     ./schemas/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:3efad19fff60b45006bb76c1bb6bd872e33a62d006dc6c6cd699c5945342814a
 , Deployment =
-    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:3db3b80586148514b4dceee0fc648fc6bbdfe3bcec99bdbad73d5cd8b87a8c13
+    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:95075afe1f761f6744124941eb40fa9f28836486ad4279de337cfd62278f7c16
 , DeploymentCondition =
     ./schemas/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:f6d653c489ad36f5ef1c422a5a8297e7e73b95210cc0e4224611c6188bad3fd5
 , DeploymentList =
-    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:1b1d7bafa2c3abd37f2feda49bf85dbbbcdfda65e0c2fdd67bc60542638ce673
+    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:d6fdab9c91b4afbad3d49a17d322737f10f214082d5298feebcdde763d5cf0ac
 , DeploymentSpec =
-    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:98eef9cb79dcb12359adce1f16e0a89eb633bbceb8fdccb929c11c9e7dd282d8
+    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:2984791e8ec1468210bb48ab0ba358949ae2192629244fc2c4bfdd1b32a8a6c6
 , DeploymentStatus =
     ./schemas/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:6c1a6f0ab5f98b0ae2aa9d861ea0ede60adbf94b1e21f0e2be39d6abe21bda39
 , DeploymentStrategy =
     ./schemas/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:f6893d857d85ff5bf089070c9a3416026483331e40c3999c52dc17d9a06bdecd
 , ReplicaSet =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:abba82d6c5c6cda66c2571388465999098eff093a34dd1131c3cd23e27e5a0dd
+    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:145a11cc0bfe78c76e7f804dc66a3a237c96e2f12527b6559c926b3c7ffae8f7
 , ReplicaSetCondition =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicaSetList =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:86e0602c387c6792792d7bea7b1f30c96e5a33f949d76d0c6f47d3ea6d191494
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:af5038e2af25cee80173ebadfd0f64ddeac3be29a27055f3ad1c08b920add618
 , ReplicaSetSpec =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:d0cbd9bfdb71d8a24072cfc567eaeb6c382b9034e12b21be8a0ac21d97316027
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:bf8d5b268864e0005a924936fc7d664fff13740e89515b2e59634d14ceff77c2
 , ReplicaSetStatus =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./schemas/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:0471cec7aab65313bb60ff3f774ee8d8c8e406f16b34f3dd27b50659055acecb
 , StatefulSet =
-    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:9e5643b5d7239dfde09ae0f3382ab3771106d3406dba03f01f41e15259a4e6e7
+    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:6d89d90b22fc4ae145d66cd6c97e7214fa58892ac888d602543a29d435e81b65
 , StatefulSetCondition =
     ./schemas/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , StatefulSetList =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:cb9f8a40ed28a86785935b2117df0defe5699401d9c4725851b070565214544d
+    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:d1b16f5824a0066a2fc1e5e53ac9d641194fd6dd8e70ee43c536ff02576714e0
 , StatefulSetSpec =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:a22459f551e2953925bdc25e5b6a30917429a01479f9ecd6d9b5680f252a6e06
+    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:9355eb02e0613b8aafee7c96ff55c1b6ef61be8d54a58cc58a953c2c189f6cb2
 , StatefulSetStatus =
     ./schemas/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:a490d193b72e53cbb9b1fe35dde9bc02415e3f01bf8ce8a516ddbad25855df42
 , StatefulSetUpdateStrategy =
@@ -159,25 +159,25 @@
 , ResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , Job =
-    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:6e47fc8cd7370b34d159a8c344e87f42b6da6272af322e9ff2d62fe5ee71561c
+    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:cad4503e7c9321e9d78d2006e0917cc6553c01ff048c473f151e34f8d0c9364f
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
-    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:11bfa57153f3e2b23a90bf42ed5948a36357ca02e6853acaef003b53962d3af8
+    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:a74530d663dfd9661d75c15a7545baa1baca53ef207e98cac979c70bb96776ee
 , JobSpec =
-    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:4cae626d4164348736870cef6aec474f7e572b94c7132e815dc13db76f4a2359
+    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:5bc8e40b3b9004df798743a136f74d264003fcf384f81c1ff5b3589807b57adb
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall sha256:ddbf73e9d4be060bdfb9aabc84c1ad30860a6ac6b37fcdbff7bbae8e473a33c1
 , CronJob =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:378339e4bb072007569bd750cfd719d4452e72e923f574f12fc0c1d1a7d6b198
+    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:ad62356c06979757d72229295c0ed149ee39bca9799630bdfb871f9aabeba417
 , CronJobList =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:aa54b705f53bdf262ffc12498c0fa1e05d6c03acb0b2240f89db0979bdf40efe
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:11245a7a215021dc4cbdb0521e9d89844a7bdc2422024bf782b2c714267c4a51
 , CronJobSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:65f6366dcb579596a41bd14d19a811cede6d8157dfd3c7c79614650388d65e9a
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:1b0aca95f2037c3dd03cfe8501bc0c2f5cd002b80b2ffd4892c293d0a61c74b5
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:aaef515cade329c5c1bccb54d90e32c20c3b7bcb96ffdee38650292cf56c10d4
 , JobTemplateSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:53b421be8fa12bd2b261a63fe1f08de5b9d04185da502784fdbf3d466f419eee
+    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:064c06bc4b92527573e55028287b852c9ff0b0e5ca2e43c2178839bafb38ff9f
 , CertificateSigningRequest =
     ./schemas/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:bed035ecc6ea4a51369aa1dfeb1ca109866762635e26abdcb1a35ff48d55386c
 , CertificateSigningRequestCondition =
@@ -435,11 +435,11 @@
 , PodStatus =
     ./schemas/io.k8s.api.core.v1.PodStatus.dhall sha256:3f3b362bc1cce319352f71c211fe1e0540c74783ca52dc284b1dd81fde5dba59
 , PodTemplate =
-    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:d7dcaa54c0b05f64eee2d4b363af42cc09d51befe5a392efff81740d214335a0
+    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:0af5f4600dfc361c47dc29ee7031d2475ed5c3b136c2aade9530217950287067
 , PodTemplateList =
-    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:5faafc49791b302c619b49e699ff2c5162f6a5e9c92f04c30412d1bcc10021a1
+    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:3fbb5de79f3a47a129d706f42eb727f447fb633d1ee4aa03bab82850fee6b3a4
 , PodTemplateSpec =
-    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:2875b8c9bba3dc179ffc18efc9cb74bb6743a2f4ade85145fb85790e87061107
+    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:56f97b078555af555e120aeafb64147af5c002584de28590e9443b31ccda663b
 , PortworxVolumeSource =
     ./schemas/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:b0bf02de5706c9f17b2dfb7f5938941151708cffc2bf1e4c69ca4a9ed1e4b735
 , PreferredSchedulingTerm =
@@ -455,13 +455,13 @@
 , RBDVolumeSource =
     ./schemas/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:ac07443af1c9f57e0175d9468507c2259feee9ea807f71ba4f5383658d62cd36
 , ReplicationController =
-    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:4af8d8570cca0f84b0bfc416e99af90dd40da830d6339da3ffdcdd6f02b2419a
+    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:5752f0f44ede0491d418b2701def9adc5a8b2213bbafe37b3fdefccdfb55d5fc
 , ReplicationControllerCondition =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicationControllerList =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:76c60ffdadcd038983b4743859f691b618e8b8d6963464e58c4f194e9532fe98
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:d1a9437714e350cbaeae9349a8063173e234eb823a7ab622e6ccf8a7e83ec412
 , ReplicationControllerSpec =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:ca9ea91cc7411c3f92e671b801da2b1cdfb22261965f662148f41c0bf7ac723a
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:d9205dc172fb792c8cbec4b7e2831cab2cd771a92b0a1da412a105cabd2e3504
 , ReplicationControllerStatus =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , ResourceFieldSelector =

--- a/1.15/types.dhall
+++ b/1.15/types.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:632934ab2ebd4cdb18c0540438c5e3f0f0cb5924b3d53b93fb91d49e8a0811cb
 , DaemonSet =
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:1548f68011d3e78a660307e21ec007b66d14108de0dc4c0d80df6957a5c56405
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:71a88f58d6239ee4a8a2cb886f6a9a4e2bbceb794841849d76276ed6c13538f9
 , DaemonSetCondition =
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , DaemonSetList =
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:399e77c6691cfc8534225b31ca63cd732d6e034c2172f2f296a0cc61408c0e9d
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:7a2e48005c357a1db1718a6c3d5f711e7144706865d9598ac6b5ffedeaa877c5
 , DaemonSetSpec =
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:d831905aab1205615c5a3085b2170349a31e96d1a3ffe7c113a0dd2a1b3348c4
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:9bbb376e02573f2ef524820afac5810de9f15ae3f343e0506e1ad4f6a849651e
 , DaemonSetStatus =
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 , DaemonSetUpdateStrategy =
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 , Deployment =
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:befebb61ebfea914eb0f4d6aeab1ec555636d98b0c65991647312f925182ad68
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:9286e399e7b201302655e86848b5e88e2a049906057af29f157e860dcd9adfb8
 , DeploymentCondition =
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 , DeploymentList =
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:6d0e4e9052041637c5d6c4f44534f08c05e2eafe8b8da38a0e3950e39f5029c2
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:dca210703cd87f0c993faa85c312ef447cc6793883eae291be9a27bd46bce0b6
 , DeploymentSpec =
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:6db80754e131daa704983cbf885bda9ca6466d3ab4451c577aceae9366eacdb7
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:77495789bc2bab88953ff6d437765ad55e45deff90d67195897d25c6439afd32
 , DeploymentStatus =
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 , DeploymentStrategy =
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 , ReplicaSet =
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:140642982bade8eb21534d4092f3be5c077d888a365e37aaaeb2111b989bc037
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:d508477b6707edec912cf980af519ced8aaa981c3d5e911f5b7004e184683db0
 , ReplicaSetCondition =
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicaSetList =
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:2a5e5e9ec99ca4f035ab198e703bd4dfdcaa2acb124fc8f29b54536557d69c72
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:2dba1a7a8bbed29c23350881a04c76dcaacadea04b261fddea98606e67eca65e
 , ReplicaSetSpec =
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:67db0ead878c974532074501883e1b905792597b91ee8de934c366f2ea1a62cc
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:0f6b95ccae2184c54da519427f015a914f0cb1d75a4e9b057da8a557add301c9
 , ReplicaSetStatus =
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 , StatefulSet =
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:57cbb0c97b06fb28416fd57f93bf794c6f020b0099680f6e049e67cabbc206d1
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:fff5f08ba0e36e11910590f2e613a82f2520dc5972f7736d957db92cd38db451
 , StatefulSetCondition =
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , StatefulSetList =
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:24fe648b8bc30a0e34481ec0360c35cbd7fd66d5ab9e253112f03fc6e5bc83e9
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:90eff57905047e0bd7f583256532e90818e7c37e64fd45da7b3f4e5ae443cf43
 , StatefulSetSpec =
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:29d6549c199bf48bfb77b50a9a54545a404361d981c7aa0422ffabe31818d828
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:04ddd9877674904fb0865e9bfe70d621e4c3b6e6834e6ecf185b649a09fe6ceb
 , StatefulSetStatus =
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 , StatefulSetUpdateStrategy =
@@ -159,25 +159,25 @@
 , ResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , Job =
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:3b76ebf6c1d9e5e21f226d02f1f2846001b8420936e2070ad91c73e5cd44f027
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:ab811bf9b9dc8fcca69512e68d35917454f7fd24c9666b142dcaa62ee8b15054
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:719cfd2bb39280c7da51160f4cef157045323d8785004f976a315a7bbdef67da
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:d2f62c3c74e8efefcaa57d39a961167013d5886fc9bc59523d39c536602b9a35
 , JobSpec =
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:c51f801c58c30bbd80d96a89faed8caacd7b9a13f7db896865ddf2c79c38beb9
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:8f251b49521f105c0981a3a4a179d9971aa268fec99348d5167207c894b47bfd
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 , CronJob =
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:113f22f7f89518bfae24f60f53df8b5fffdf4c7b64a1030c6676e9e193c74359
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:2d6f3b63f34d0f8e89d705ca6142b81813b3b9c6eb52811559a19a5b5367745f
 , CronJobList =
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:561b2feb9bff0046e13c74bd7e398e5a589d04dac0b21f5da3d6524b49a53ee6
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:e16a9159769249cee8467c58411d752742565f40a68363525070ba40fa50f022
 , CronJobSpec =
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:ab1a11e5994b07769f61c9a48265c92ded4174abe206cccd3da0300f4294fe2d
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:e828b4c396978ae8feddab8c5c97812b7812b3c061b0c59f782e27d003f42a6d
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 , JobTemplateSpec =
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:01242dc043815fa7615667144b432492bf2f520e459f5207bf81899b306d5a90
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:3a7fec87393b849175d71adfe4155da4b47a54c8dc8d03945fa9b52ee4645808
 , CertificateSigningRequest =
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:7e3dc09021753aeb2f841d9aa33f0e1e0119a7a7e597e4355387e011165226f5
 , CertificateSigningRequestCondition =
@@ -435,11 +435,11 @@
 , PodStatus =
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:391332987a601de8c7eb411e62d54495dd8231e7104c4e3f22043b6aea26319f
 , PodTemplate =
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:753f310614c749c4f8a608cfafe3df7ebd734c8f03c9e3bd998f57b0983f4b51
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:9941b30a6e675b7876a6bc749f908287beeb62a4cdd9085f808559bea440584f
 , PodTemplateList =
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:56fcc24c85cde9e50ba8fba0af4eda6754187b70b072724c3c1b167694bb572c
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:7aa2ed000e68ed2c744a4db4ecd62d4418d56c9b8c12e7fedb597d1839d7a45e
 , PodTemplateSpec =
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:ca8e23bc1c0223aa9befd3b599cbe36a10e60bcaf143d438794993b79f893cf8
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:98da881271e6c3e3dc167928c6c9ee3cabf7c0e7b9ceb71afa2565514be162e7
 , PortworxVolumeSource =
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 , PreferredSchedulingTerm =
@@ -455,13 +455,13 @@
 , RBDVolumeSource =
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 , ReplicationController =
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:c8148400d21aea8a8b028d94461eb7ad27d97c1ee284f7ec77d9a250c3ab920c
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:f798261cb0701bbd182e5ac19f70e300196b6c1765a3adf361c022cccced23a6
 , ReplicationControllerCondition =
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicationControllerList =
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:143f267f544ecf2519f37d57583d05033b65cd17bc6939670265d42ed3e278b6
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:b20cc6a3131a7db22d37a6089d26b9da1e2840cd6a55b6a6a935903671aa0716
 , ReplicationControllerSpec =
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:d0dc7a10a26c268ca54c87d598e0bbb16e5543b3cfe88dfec37a569ff8793cf7
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:e4d55ff63f4acf3c07263317a5a78ff14df7cc45ae1ed154ff54875c038ca238
 , ReplicationControllerStatus =
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , ResourceFieldSelector =

--- a/1.15/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.15/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.15/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.15/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.15/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.15/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.core.v1.PodSpec.dhall
 }

--- a/1.15/typesUnion.dhall
+++ b/1.15/typesUnion.dhall
@@ -17,37 +17,37 @@
 | ControllerRevisionList :
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:632934ab2ebd4cdb18c0540438c5e3f0f0cb5924b3d53b93fb91d49e8a0811cb
 | DaemonSet :
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:1548f68011d3e78a660307e21ec007b66d14108de0dc4c0d80df6957a5c56405
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:71a88f58d6239ee4a8a2cb886f6a9a4e2bbceb794841849d76276ed6c13538f9
 | DaemonSetCondition :
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | DaemonSetList :
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:399e77c6691cfc8534225b31ca63cd732d6e034c2172f2f296a0cc61408c0e9d
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:7a2e48005c357a1db1718a6c3d5f711e7144706865d9598ac6b5ffedeaa877c5
 | DaemonSetSpec :
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:d831905aab1205615c5a3085b2170349a31e96d1a3ffe7c113a0dd2a1b3348c4
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:9bbb376e02573f2ef524820afac5810de9f15ae3f343e0506e1ad4f6a849651e
 | DaemonSetStatus :
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 | DaemonSetUpdateStrategy :
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 | Deployment :
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:befebb61ebfea914eb0f4d6aeab1ec555636d98b0c65991647312f925182ad68
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:9286e399e7b201302655e86848b5e88e2a049906057af29f157e860dcd9adfb8
 | DeploymentCondition :
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 | DeploymentList :
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:6d0e4e9052041637c5d6c4f44534f08c05e2eafe8b8da38a0e3950e39f5029c2
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:dca210703cd87f0c993faa85c312ef447cc6793883eae291be9a27bd46bce0b6
 | DeploymentSpec :
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:6db80754e131daa704983cbf885bda9ca6466d3ab4451c577aceae9366eacdb7
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:77495789bc2bab88953ff6d437765ad55e45deff90d67195897d25c6439afd32
 | DeploymentStatus :
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 | DeploymentStrategy :
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 | ReplicaSet :
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:140642982bade8eb21534d4092f3be5c077d888a365e37aaaeb2111b989bc037
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:d508477b6707edec912cf980af519ced8aaa981c3d5e911f5b7004e184683db0
 | ReplicaSetCondition :
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicaSetList :
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:2a5e5e9ec99ca4f035ab198e703bd4dfdcaa2acb124fc8f29b54536557d69c72
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:2dba1a7a8bbed29c23350881a04c76dcaacadea04b261fddea98606e67eca65e
 | ReplicaSetSpec :
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:67db0ead878c974532074501883e1b905792597b91ee8de934c366f2ea1a62cc
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:0f6b95ccae2184c54da519427f015a914f0cb1d75a4e9b057da8a557add301c9
 | ReplicaSetStatus :
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | RollingUpdateDaemonSet :
@@ -57,13 +57,13 @@
 | RollingUpdateStatefulSetStrategy :
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 | StatefulSet :
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:57cbb0c97b06fb28416fd57f93bf794c6f020b0099680f6e049e67cabbc206d1
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:fff5f08ba0e36e11910590f2e613a82f2520dc5972f7736d957db92cd38db451
 | StatefulSetCondition :
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | StatefulSetList :
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:24fe648b8bc30a0e34481ec0360c35cbd7fd66d5ab9e253112f03fc6e5bc83e9
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:90eff57905047e0bd7f583256532e90818e7c37e64fd45da7b3f4e5ae443cf43
 | StatefulSetSpec :
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:29d6549c199bf48bfb77b50a9a54545a404361d981c7aa0422ffabe31818d828
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:04ddd9877674904fb0865e9bfe70d621e4c3b6e6834e6ecf185b649a09fe6ceb
 | StatefulSetStatus :
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 | StatefulSetUpdateStrategy :
@@ -159,25 +159,25 @@
 | ResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | Job :
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:3b76ebf6c1d9e5e21f226d02f1f2846001b8420936e2070ad91c73e5cd44f027
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:ab811bf9b9dc8fcca69512e68d35917454f7fd24c9666b142dcaa62ee8b15054
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:719cfd2bb39280c7da51160f4cef157045323d8785004f976a315a7bbdef67da
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:d2f62c3c74e8efefcaa57d39a961167013d5886fc9bc59523d39c536602b9a35
 | JobSpec :
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:c51f801c58c30bbd80d96a89faed8caacd7b9a13f7db896865ddf2c79c38beb9
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:8f251b49521f105c0981a3a4a179d9971aa268fec99348d5167207c894b47bfd
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 | CronJob :
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:113f22f7f89518bfae24f60f53df8b5fffdf4c7b64a1030c6676e9e193c74359
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:2d6f3b63f34d0f8e89d705ca6142b81813b3b9c6eb52811559a19a5b5367745f
 | CronJobList :
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:561b2feb9bff0046e13c74bd7e398e5a589d04dac0b21f5da3d6524b49a53ee6
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:e16a9159769249cee8467c58411d752742565f40a68363525070ba40fa50f022
 | CronJobSpec :
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:ab1a11e5994b07769f61c9a48265c92ded4174abe206cccd3da0300f4294fe2d
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:e828b4c396978ae8feddab8c5c97812b7812b3c061b0c59f782e27d003f42a6d
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 | JobTemplateSpec :
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:01242dc043815fa7615667144b432492bf2f520e459f5207bf81899b306d5a90
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:3a7fec87393b849175d71adfe4155da4b47a54c8dc8d03945fa9b52ee4645808
 | CertificateSigningRequest :
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:7e3dc09021753aeb2f841d9aa33f0e1e0119a7a7e597e4355387e011165226f5
 | CertificateSigningRequestCondition :
@@ -435,11 +435,11 @@
 | PodStatus :
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:391332987a601de8c7eb411e62d54495dd8231e7104c4e3f22043b6aea26319f
 | PodTemplate :
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:753f310614c749c4f8a608cfafe3df7ebd734c8f03c9e3bd998f57b0983f4b51
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:9941b30a6e675b7876a6bc749f908287beeb62a4cdd9085f808559bea440584f
 | PodTemplateList :
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:56fcc24c85cde9e50ba8fba0af4eda6754187b70b072724c3c1b167694bb572c
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:7aa2ed000e68ed2c744a4db4ecd62d4418d56c9b8c12e7fedb597d1839d7a45e
 | PodTemplateSpec :
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:ca8e23bc1c0223aa9befd3b599cbe36a10e60bcaf143d438794993b79f893cf8
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:98da881271e6c3e3dc167928c6c9ee3cabf7c0e7b9ceb71afa2565514be162e7
 | PortworxVolumeSource :
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 | PreferredSchedulingTerm :
@@ -455,13 +455,13 @@
 | RBDVolumeSource :
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 | ReplicationController :
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:c8148400d21aea8a8b028d94461eb7ad27d97c1ee284f7ec77d9a250c3ab920c
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:f798261cb0701bbd182e5ac19f70e300196b6c1765a3adf361c022cccced23a6
 | ReplicationControllerCondition :
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicationControllerList :
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:143f267f544ecf2519f37d57583d05033b65cd17bc6939670265d42ed3e278b6
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:b20cc6a3131a7db22d37a6089d26b9da1e2840cd6a55b6a6a935903671aa0716
 | ReplicationControllerSpec :
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:d0dc7a10a26c268ca54c87d598e0bbb16e5543b3cfe88dfec37a569ff8793cf7
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:e4d55ff63f4acf3c07263317a5a78ff14df7cc45ae1ed154ff54875c038ca238
 | ReplicationControllerStatus :
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | ResourceFieldSelector :

--- a/1.16/defaults.dhall
+++ b/1.16/defaults.dhall
@@ -17,7 +17,7 @@
 , ControllerRevisionList =
     ./defaults/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:2343b690c1c4d49b5e1fe09da5a71fc9e8c74f2a9975764b0ad41cf597b6b616
 , DaemonSet =
-    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:9c2b82b4d9b61bf7de9ed063f67198be6ec6e38d6589210caa4ac442c542e83d
+    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:7e84a4861a5b40048e962d0ee1ccc07d4a870f424eaf6497f7db414ea5385cd9
 , DaemonSetCondition =
     ./defaults/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , DaemonSetList =
@@ -29,7 +29,7 @@
 , DaemonSetUpdateStrategy =
     ./defaults/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:0267659f9e8647bbf2e9f9073536c4c0c60b8ff1c076523cd7773b05e8d1c270
 , Deployment =
-    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:bc5d39541156f0890affabca1980bd390ba311dc96f719af6633e418a8befa70
+    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:dfc8c44b68fa3834d307b5d19922568b27bdf8947a39417a2a028c4f473c37ad
 , DeploymentCondition =
     ./defaults/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:006ebe956ae6e2918eb18beed3f6378d0f79437bfc449f4b6c7852206a7c7e5d
 , DeploymentList =
@@ -41,13 +41,13 @@
 , DeploymentStrategy =
     ./defaults/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:e5ba779274cb5a0b72069647e1aa8b257380ddb3b183aef45233028c399f65b9
 , ReplicaSet =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:d824c0006c7892cc3996ed0d51805a8cffe0da64dd440206c19095ae6873af7a
+    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:d952a5348c44febfe6f4926cdf9311c8b72ba314773a6b78052ec2f456a1b973
 , ReplicaSetCondition =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicaSetList =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:e57739bf261dfcdaec492632f1986b57c7d7bc45a4ba7be145beb64b739fe70f
 , ReplicaSetSpec =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:2b277eede16e00df6e6591bd097e33bd73c5db24a4b2e8dca9e01ce056915a05
+    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:8a924dfd2fc23e587fb04ad1b7de0d05eba8a94f90fc0f0a354a4c84672f8abe
 , ReplicaSetStatus =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , RollingUpdateDaemonSet =
@@ -57,7 +57,7 @@
 , RollingUpdateStatefulSetStrategy =
     ./defaults/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:4d9feb8034f9f58692aebeed06474c07c387e5b8bc11c40dc36ec6390a26fa63
 , StatefulSet =
-    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:32c92803bcb882be48429e70d50d97069511c270dfc05c516cefce426546fe37
+    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:e81c471c250ee2c42849e1a78b542020f96135fe36d4a91cd7603df6c3d0b87e
 , StatefulSetCondition =
     ./defaults/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , StatefulSetList =
@@ -167,7 +167,7 @@
 , ResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Job =
-    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:5c78479e53256aa59d2a4c1735561a923edd9a660050182a06967ca5d7748035
+    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:27ca3bcf46f7c29946a204f553bafa9efa66becf60befdb177054c74d66ec86a
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
 , JobList =
@@ -177,7 +177,7 @@
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall sha256:acf4f792ff1e56e53cb6d00ddc60f6ade85c44289efcbbfd2e5b81e1ac0347fc
 , CronJob =
-    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:be38e61d6ea5e5f46bdc46ae48787cb2a646f5d1d5bd38c92e12824def67a816
+    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:bafc51976af6a7fa2be45b03f9665aa02bd4206f289fe30b2a6a17636a49a94e
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:d6f792b6d1f5cc8e862708490973d8b46eeb2d7adf4f3be3170a93ce2b70be7a
 , CronJobSpec =
@@ -185,7 +185,7 @@
 , CronJobStatus =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:751a6c74f8753d8467f43f76bc3b0661655a65daf9f907f6f814f01ade0fcd70
 , JobTemplateSpec =
-    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:1211b8981368acd30b2d3eb5b31fb5726e1c043c3c833d10486327f4d64ab8da
+    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:6b523b171dcdc85569564988abf8b3b729c6c417384bdc9921ab2ae5c8f42ec1
 , CertificateSigningRequest =
     ./defaults/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:fc1ae5e4b43cbc3d6410fce82d6859e180c77ce5b9c643b2562588f85e1ab780
 , CertificateSigningRequestCondition =
@@ -449,11 +449,11 @@
 , PodStatus =
     ./defaults/io.k8s.api.core.v1.PodStatus.dhall sha256:1e5a1592d9c192d7d2021e9fde347019503a365372fe7c9b0af203477399a7ef
 , PodTemplate =
-    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:357fa8331c18f0ab168cd17e99f615c80a1a5602c229739a0263883c21190492
+    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:7ea50a8d94ddbec5e5fb9b99725a113fcc571588b5fb8c8ef6754cfb252ca07b
 , PodTemplateList =
     ./defaults/io.k8s.api.core.v1.PodTemplateList.dhall sha256:51ca93c255c7ab48ec42245f8b34a4effdd072cd019931f37ef304d8b46d6e6f
 , PodTemplateSpec =
-    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:4cabdcf0d97f7a1d52efd179d9bf7d0c2000565dad2d364b4037b1cae23faa89
+    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:f824d049f1e1e3f03e903d662b86355c60751b60724433c8c0fb4cffaf584f40
 , PortworxVolumeSource =
     ./defaults/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:5d8e73366d928941a81088f57aaf538a8c3a8d171086228dcefe3aa8084e6a0a
 , PreferredSchedulingTerm =
@@ -469,13 +469,13 @@
 , RBDVolumeSource =
     ./defaults/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:0c1b0c6ed400fe9c63c9a97d77d6d6a69463137e0e43687c4087b7e8cce747c3
 , ReplicationController =
-    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:2a0f96cef7575592868866dcc81cb86d4e14844c441c9749d8c51c0d0279827b
+    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:f58f6ba78c0f9d7bf7650cab3a513b5924ca7c4987e96e0565fc002b28715097
 , ReplicationControllerCondition =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicationControllerList =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:e7dcae86af1b284f62a6f26fe1e432a6a27a9fa5c3100acdad84794ac21ed769
 , ReplicationControllerSpec =
-    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:882a84d65a27349b3fa9f9c9c3f172543703d695f93164dd61aca2b9c83cdb01
+    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:d5c6a4589d1ad66024786a3ef0908c928f76f9edc7b719c186e9605d879dfbb6
 , ReplicationControllerStatus =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , ResourceFieldSelector =

--- a/1.16/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.16/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.16/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.16/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.16/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.16/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall
+}

--- a/1.16/package.dhall
+++ b/1.16/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:a0273080817719618ee4d14e162286999c3de78bcfaa7fc826db45b61f94f957
+  ./schemas.dhall sha256:3e9b85811182419b3cf09bee52ba013836b5a403b12bab7a621b11e77dc8e0dc
 ∧ { IntOrString =
-      ( ./types.dhall sha256:8df69a27a548a702719b2b91b28db2b1395fa744a1afa55f76d4a85312b5c3a1
+      ( ./types.dhall sha256:caa6ea1b394352be1a7cf82bac332f16f2cfb06bd0007bb8d946d2c45ee85670
       ).IntOrString
   , Resource =
-      ./typesUnion.dhall sha256:56e87d9078fcdba6430a42b3d153552a644cc520b0544b45598babb500ed90a9
+      ./typesUnion.dhall sha256:dac74a3aca2c92a93851a3143f4968255704aa58126a537ac86fcbd0128dc1cd
   }

--- a/1.16/schemas.dhall
+++ b/1.16/schemas.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./schemas/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:139727b422a6c643c13a021400e75ed9df5bd955c86439c018a1bbb5ac51f802
 , DaemonSet =
-    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:5d815a3bd966899a87397e0dc8e7cd2841b094e7b17c019c06699efebd0dc8e7
+    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:a98f8369bf5a7fce3638e9cfb625f3407e80d901d899477ba8f58d9957fd1507
 , DaemonSetCondition =
     ./schemas/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , DaemonSetList =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:131a77baea0d738690321f5d456008e1fe7949e29d3fe385052fa17a5c3a9454
+    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:afe8d9d4791b15a04065146349114b8ba646cd859535fdda9b8df28a8c0f2e4d
 , DaemonSetSpec =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:a9d67d0d354bc3c825592deb0484f18e8adeecd2d771b43e37758ebc3fcc193b
+    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:74e592cf81c86f91e06def139a5881b3acdb01e4c0ac92cad29c984cc7f56871
 , DaemonSetStatus =
     ./schemas/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:a68e46f267e6a5071080338953f8b1d13dff20cbfc06ae4b25f7645ff0b6cff6
 , DaemonSetUpdateStrategy =
     ./schemas/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:3efad19fff60b45006bb76c1bb6bd872e33a62d006dc6c6cd699c5945342814a
 , Deployment =
-    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:ed698f94befbcf580a1556a9c0f4ef72b8769a335f6525e5b19097e391fc1702
+    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:6bfafb31e27a670958cafeed16a94f9f102f0e8cea64e79c4ff42bc99ca8f93f
 , DeploymentCondition =
     ./schemas/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:f6d653c489ad36f5ef1c422a5a8297e7e73b95210cc0e4224611c6188bad3fd5
 , DeploymentList =
-    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:fbff5c25e797a64dbba75b65f383ec1dcd02218cdcf94db08b31b5b76c1418b3
+    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:7e906a597249cb1879e94cb9544c896fee797e3d04dcc8c36f6ce196c82a91c3
 , DeploymentSpec =
-    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:54059b7e4786b471c8526cb72abf71f4135258c973b4e73149521c806a65117f
+    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:de800a9f105d05e727d5752d27b7070dbbf926e832ecbe929dfea159b331df83
 , DeploymentStatus =
     ./schemas/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:6c1a6f0ab5f98b0ae2aa9d861ea0ede60adbf94b1e21f0e2be39d6abe21bda39
 , DeploymentStrategy =
     ./schemas/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:f6893d857d85ff5bf089070c9a3416026483331e40c3999c52dc17d9a06bdecd
 , ReplicaSet =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:a444e529a8c9644c96a09d35177f9e1213b4be727c1b742dd28c8e2becb5934e
+    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:4201414c67b27cf8affb3a3add69d9fcf176726460e17869bed52bbd6891b4f1
 , ReplicaSetCondition =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicaSetList =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:b15e3afa6156a74c83a77a0d5db98495a0fac5f76f127f995a1db378c7613eae
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:5fc4425b1d8aff2677b6dc07190adde0536053f94e4e2bbe0432bd3e88706c44
 , ReplicaSetSpec =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:67333e3351ccdf0026902c1b135bfcb83f6b917fe2e1a43599678c2ddffd6a4b
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:460e737b0d110f5b57b6dd5203ef485416a0897feb0c31492e19c2ac6dc6640b
 , ReplicaSetStatus =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./schemas/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:0471cec7aab65313bb60ff3f774ee8d8c8e406f16b34f3dd27b50659055acecb
 , StatefulSet =
-    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:5e736bc483603e0fead8bf45af53c680555c619c61e9817b3ab8e50c371c4e1a
+    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:0f2db135a956a3d41b91920494f40541b534ba8208010b63c047f38f0dceaf17
 , StatefulSetCondition =
     ./schemas/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , StatefulSetList =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:97b9460b37a14cbc39deb917d1e83e9944861784e51453496ff17646cb8acadc
+    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:ea520cddad7c27491e44ade3e40770643efb305c81edde6bbab1997828cb160f
 , StatefulSetSpec =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:ef36289d738b94a68d13fd7be8a7334fd5b6244af92e42d81565bfdd7e1ac56b
+    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:43865c86843ec6369c45fb6c280905555a60b09296f7ea5f692c2f5ce045c6cc
 , StatefulSetStatus =
     ./schemas/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:a490d193b72e53cbb9b1fe35dde9bc02415e3f01bf8ce8a516ddbad25855df42
 , StatefulSetUpdateStrategy =
@@ -167,25 +167,25 @@
 , ResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , Job =
-    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:d9d53376574d04c578507abd96f0e12c73845d4851cba851180300d180b0951c
+    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:ced8121d45ddf417ced464f1fb38cd14a153bc8fca47cc23ccbf5ae13be0ace8
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
-    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:df74c374c24dd01cd338892fcdcdb80964246f7c11e452fb8367610b4ae8117e
+    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:2ce99dbb14d0eb0fca9c1cc9539bbaa9ddc81e44f201e0198ee9960b769cb29b
 , JobSpec =
-    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:de6a0b5a1eeed221345f056e15c8c63acfa4ce695eef1eb37dc79d1d6e449be3
+    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:557f3eb178aaa95a6e28cda2df0b15adb40ed8c1df3086aafb106242f60d6d94
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall sha256:ddbf73e9d4be060bdfb9aabc84c1ad30860a6ac6b37fcdbff7bbae8e473a33c1
 , CronJob =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:1c123d52f3a3cdb08a1f48f7e877536a0d1aa660f1c9f13823d531b111fbb1ff
+    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:3617bf893f1943bcfd057900582ca5fcaed3941a03602d7bf104612d73ec83db
 , CronJobList =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2127dbe9f1e48d3bc3bc312402b7b3bda0877e203e46d13555f1fa80d5f94313
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:513362f795f3981604de48833466783de151afbf2f536a3fda7653b2f210f1e6
 , CronJobSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:6679ca5c5b62ac38d1644dd7846b2b87a558fe268d014f0cd12fd4639cbdef16
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:46000e81129aab5db7d1f431f89be99a63f3a91914b23f51bbebb4de76c0b396
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:aaef515cade329c5c1bccb54d90e32c20c3b7bcb96ffdee38650292cf56c10d4
 , JobTemplateSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:0d54598c4445dd179b95fc5e27c55035c0a7488edac46cfed897a97ef694e9ee
+    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:f977128acbb9dee2b7e3cd34cc1c7d6f7ff0e6b87695b6ce2bbbc3d8b244c688
 , CertificateSigningRequest =
     ./schemas/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:8da55ca2b6f4a03970fe6edc1f75666ec6064ce61141fa3296c7231fe74f035b
 , CertificateSigningRequestCondition =
@@ -449,11 +449,11 @@
 , PodStatus =
     ./schemas/io.k8s.api.core.v1.PodStatus.dhall sha256:bca3d68a0c9b023f53c79aa7cea5e3d5181fd460adf03d0732f60edf82e845fe
 , PodTemplate =
-    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:8a3569e1b3b0bc4d455c3d543317ab5a4bb725e1c4d8993b4de9658f2af38bdd
+    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:d0436a8fe4eb82527320a7a00306a92a4884cc1d7ed3750fa3e458e90eeeda33
 , PodTemplateList =
-    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:12f302efe97b1b40217fabc4b653035359a9d7aedf1f1b667def58e87499eeb6
+    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:8b7bde124eaecc9e0f531675e0be8290e13b630e3fdce7b6b278c83bc86c4bab
 , PodTemplateSpec =
-    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:75c14c8d571e9a997314df9f56bd19df6ac2e60663a87aa9ab44b5e620da06a7
+    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:9c406f98ae7ebbc539ce838e5c4866eb15c20f48ed9025d300b1cc59dddccd3b
 , PortworxVolumeSource =
     ./schemas/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:b0bf02de5706c9f17b2dfb7f5938941151708cffc2bf1e4c69ca4a9ed1e4b735
 , PreferredSchedulingTerm =
@@ -469,13 +469,13 @@
 , RBDVolumeSource =
     ./schemas/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:ac07443af1c9f57e0175d9468507c2259feee9ea807f71ba4f5383658d62cd36
 , ReplicationController =
-    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:e08820db40bad5895437dafd248e7f85f5919da4a07b638e5dae168011951785
+    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:5684789e2d015eb77100370822874391dd102999a9fbd5c548a0b60032e56e3e
 , ReplicationControllerCondition =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicationControllerList =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:15169144ab38df6b4f44691ccf74a5d746dc878dfb2d1d07816e0c754eb0a836
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:cfe3c12ff92308d8e836c7c7ef541a762c50e047c8ff43273d42a244573796c2
 , ReplicationControllerSpec =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:a256090fbd1d0570f7f649424bc8458bea0c826c947d04b6df7f0e02f3f0fe00
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:2a6cdb0600e8d966baa0f093eac3b1fd8fd69834051ea9d37d9955487f838754
 , ReplicationControllerStatus =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , ResourceFieldSelector =

--- a/1.16/types.dhall
+++ b/1.16/types.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:209723e7a750dc2b67fb355e9847f70439fecc3d68e97ae2d20d9b0f33f1c643
 , DaemonSet =
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:0fa760b6fc3995c392036494d484eba95f85e74a470eb7e3463147ae8fb8b646
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:e46d62a02728158d09b6a205ef02f987b282acf366fafda9ff27017be4f8cea2
 , DaemonSetCondition =
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , DaemonSetList =
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:350c6e2a0e6f421d995d80fcad1628ed5c1e5445408534091a2262bca1534a02
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:672559b89b2f8ae28cd9e313131128b99ad7b4b912d7171f139985923cd95f0d
 , DaemonSetSpec =
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:f653e781d6af8a93e56c5134f1a698d9512d74d626acc53d66bfa60895c452cc
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:a15bc4d1fa7c70f88c9aaeb4ad076087918dde32a3461071bcd02740c40b44d6
 , DaemonSetStatus =
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 , DaemonSetUpdateStrategy =
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 , Deployment =
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:d151757b70d96a465afd0edbe49f493aee9a2671d2a52166535f46c3468d4c1a
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:46bd74ccf0e6c6a5c3b71f271f8417de954c06c0c82b80664731e5b8b50bb8d8
 , DeploymentCondition =
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 , DeploymentList =
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:0bcfbf8a0cc54cb8b7ca0947969b94c8a0b01d8f32c225e3e988804390177dd8
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:1a2ad78552ff0c7bdfc8b50a2e03738a9f2bc917409a19899667a1c1ee2c4a20
 , DeploymentSpec =
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:1aa0e0d14a7b2932a29529a2297f245555fe68e9131cdbc5e19be401c34eb19d
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:10c07527edf1662a7c9109f948ebc7dd2389800638b029b405ef29eeafa106b2
 , DeploymentStatus =
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 , DeploymentStrategy =
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 , ReplicaSet =
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:b4342465f4b1cc36d2174a30e3a6cf448a763d8d0fdcf4b1fd662345397d58d7
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:4c427eb8762cb3a481c2f76041f18d48783567f652b6cfd1cef310827b4c43c6
 , ReplicaSetCondition =
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicaSetList =
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:5bc6183e381ff2dadefed4283b570de07dd7a836bbb74fa3dbc588c926ca9492
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:ed4a3f0d31b29d076200f32994dde29a040af4c95b2d7c23cbaaf273531b678b
 , ReplicaSetSpec =
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:61175713ff8861c718e5ae9f4c548ec9e820438f25b1cf197bc80196ae73cfed
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:e7038dd29d1f1c42c6e5232e559286eb25e26a642be58f524cda35498ca154cb
 , ReplicaSetStatus =
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 , StatefulSet =
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:6ffeb8022959eadf48afe0da1095d9ab2844f740937898eed4486308331b6b13
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:ddaed92c80451da9f167395975815b66484611c0dcc0a38d6d7098fef0184403
 , StatefulSetCondition =
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , StatefulSetList =
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:ce8f44a55a45992e315cfc978c1196ab121d3b61c91f9000402b7a896a43b249
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:4fb9bcd2e600851cff7758024177253a141c0baf541a9ee5c05537edf91dbce4
 , StatefulSetSpec =
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:d4a6c6ad0c1ac7bf9fbc2c51b9fb92fcfef170ce9b9e4477c32ef66f85bc7406
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:794f83ce9e9074e4df43cb26ea36a9dcb65769c613f9ddd6293c7e814d9131af
 , StatefulSetStatus =
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 , StatefulSetUpdateStrategy =
@@ -167,25 +167,25 @@
 , ResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , Job =
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:830e84490c63b021a1ea2a3cd4aa17e421e5d8578324472ed94f3cc0d18c2032
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:e1f71eaac731107357dff30094a05e285f521daae62643ec01296b4cc5ff7627
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:517b576e15724c01fa49dc1f4e4f8e70cb6cbb5daf5a2cfa7fcc1d48b4fc3a23
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:b83c089c7bf30e8ab65d519c3a465ed0798ca53fd07ffc47bf210169dda1a366
 , JobSpec =
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:889c6603b392cdbcf252a97889b14807dc1bc7b320fc71ca1a1ab1dcf76a7a12
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:c530e13d02354d0d76e2724fca7669fad7bae521b5f886a2a7e3a4fb1cce8dd1
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 , CronJob =
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:1bf6fca7cc5036804c83812fc9bbae6f5fac0e462328d18dbb1d6903258e36c8
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:a54e82e450036228d20ede8137d234ca5b1be08c36e426f8637909cecfe99154
 , CronJobList =
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:63e4ccbe79cd8fb418109e137cb90d89df6eb2fdf4e53780985f9a06bc13af01
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2abef70c1fa349ee511383af297495e954f2004f42dcded0117b363239f0edc6
 , CronJobSpec =
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:05300da941e48bb5bd67081bdb3e993528235a1d7f8948ba112ddbd3100b7f33
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:34f04d816146839ebbbf2b40ee821b841951082a2510085cff13b48fec30af92
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 , JobTemplateSpec =
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:959eee751ac9bdfffce59990061969d2509d4dfdf17fb8201825db239bf74bd4
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:dde76a9967501e8ebd29ead0776076ef513f6d631c5f5f47141774ca9cb7147c
 , CertificateSigningRequest =
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:ccb53f3c9720d799c9a280b23565de25ab1992b701d52ca6c8f8e7fa21fdb977
 , CertificateSigningRequestCondition =
@@ -449,11 +449,11 @@
 , PodStatus =
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:76800003e551406fea214c10166149b231668764a166a11579a1dcb8eac94d81
 , PodTemplate =
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:4076a1a0fdf2e4272f7921ed1ecf046cec4e71c15c738f938541476b884c42f6
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:e1a17029139b4a38a808f7f58600db7be1042aa6287e6e6b5823c87e39081a9b
 , PodTemplateList =
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:b2e45861cc05b3cecf61320937f628ce14e9ffdf3b02ff23aad2d475196e4505
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:eedf95a2ddb51f7f322678b9b299d5fae0a77a21c8226589fcc805a6f09f533c
 , PodTemplateSpec =
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:8eea21c0ace52dd3f671f41d6de30abdfb10ba05bf0b44f571472a6a6d689b1f
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:09352eb34dcecefa84e22b93423136bfd37f60b23b564bd6d2a29fd9abfa4e3f
 , PortworxVolumeSource =
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 , PreferredSchedulingTerm =
@@ -469,13 +469,13 @@
 , RBDVolumeSource =
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 , ReplicationController =
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:cd15e5d7af5ebc0aea08a47fb6ffccf40bc9f1dcb9e12070d03ccebe75fd86b7
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:cb1a847cd82fabcaf19114d3d3c8559d93eaade96721f2b66ee9161b6dd4f53d
 , ReplicationControllerCondition =
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicationControllerList =
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:a37322f3cc1a3e21dd963e5c747fb1feab94bab8a10a3c0a867be2feb89ad6d2
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:353186aaf8f8c66413d34bf07aaf03c2d11406d91e8865ac123a512116897f36
 , ReplicationControllerSpec =
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:996ac4204e547f4db3c40644affa7fc436f6ee84666012e316e40036b166129b
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:97d0a875908f491b593d1a4e5b648b05b62ea228565c13c4ebe9d814a7b142bf
 , ReplicationControllerStatus =
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , ResourceFieldSelector =

--- a/1.16/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.16/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.16/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.16/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.16/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.16/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.core.v1.PodSpec.dhall
 }

--- a/1.16/typesUnion.dhall
+++ b/1.16/typesUnion.dhall
@@ -17,37 +17,37 @@
 | ControllerRevisionList :
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:209723e7a750dc2b67fb355e9847f70439fecc3d68e97ae2d20d9b0f33f1c643
 | DaemonSet :
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:0fa760b6fc3995c392036494d484eba95f85e74a470eb7e3463147ae8fb8b646
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:e46d62a02728158d09b6a205ef02f987b282acf366fafda9ff27017be4f8cea2
 | DaemonSetCondition :
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | DaemonSetList :
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:350c6e2a0e6f421d995d80fcad1628ed5c1e5445408534091a2262bca1534a02
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:672559b89b2f8ae28cd9e313131128b99ad7b4b912d7171f139985923cd95f0d
 | DaemonSetSpec :
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:f653e781d6af8a93e56c5134f1a698d9512d74d626acc53d66bfa60895c452cc
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:a15bc4d1fa7c70f88c9aaeb4ad076087918dde32a3461071bcd02740c40b44d6
 | DaemonSetStatus :
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 | DaemonSetUpdateStrategy :
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 | Deployment :
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:d151757b70d96a465afd0edbe49f493aee9a2671d2a52166535f46c3468d4c1a
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:46bd74ccf0e6c6a5c3b71f271f8417de954c06c0c82b80664731e5b8b50bb8d8
 | DeploymentCondition :
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 | DeploymentList :
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:0bcfbf8a0cc54cb8b7ca0947969b94c8a0b01d8f32c225e3e988804390177dd8
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:1a2ad78552ff0c7bdfc8b50a2e03738a9f2bc917409a19899667a1c1ee2c4a20
 | DeploymentSpec :
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:1aa0e0d14a7b2932a29529a2297f245555fe68e9131cdbc5e19be401c34eb19d
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:10c07527edf1662a7c9109f948ebc7dd2389800638b029b405ef29eeafa106b2
 | DeploymentStatus :
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 | DeploymentStrategy :
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 | ReplicaSet :
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:b4342465f4b1cc36d2174a30e3a6cf448a763d8d0fdcf4b1fd662345397d58d7
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:4c427eb8762cb3a481c2f76041f18d48783567f652b6cfd1cef310827b4c43c6
 | ReplicaSetCondition :
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicaSetList :
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:5bc6183e381ff2dadefed4283b570de07dd7a836bbb74fa3dbc588c926ca9492
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:ed4a3f0d31b29d076200f32994dde29a040af4c95b2d7c23cbaaf273531b678b
 | ReplicaSetSpec :
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:61175713ff8861c718e5ae9f4c548ec9e820438f25b1cf197bc80196ae73cfed
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:e7038dd29d1f1c42c6e5232e559286eb25e26a642be58f524cda35498ca154cb
 | ReplicaSetStatus :
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | RollingUpdateDaemonSet :
@@ -57,13 +57,13 @@
 | RollingUpdateStatefulSetStrategy :
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 | StatefulSet :
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:6ffeb8022959eadf48afe0da1095d9ab2844f740937898eed4486308331b6b13
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:ddaed92c80451da9f167395975815b66484611c0dcc0a38d6d7098fef0184403
 | StatefulSetCondition :
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | StatefulSetList :
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:ce8f44a55a45992e315cfc978c1196ab121d3b61c91f9000402b7a896a43b249
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:4fb9bcd2e600851cff7758024177253a141c0baf541a9ee5c05537edf91dbce4
 | StatefulSetSpec :
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:d4a6c6ad0c1ac7bf9fbc2c51b9fb92fcfef170ce9b9e4477c32ef66f85bc7406
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:794f83ce9e9074e4df43cb26ea36a9dcb65769c613f9ddd6293c7e814d9131af
 | StatefulSetStatus :
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 | StatefulSetUpdateStrategy :
@@ -167,25 +167,25 @@
 | ResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | Job :
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:830e84490c63b021a1ea2a3cd4aa17e421e5d8578324472ed94f3cc0d18c2032
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:e1f71eaac731107357dff30094a05e285f521daae62643ec01296b4cc5ff7627
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:517b576e15724c01fa49dc1f4e4f8e70cb6cbb5daf5a2cfa7fcc1d48b4fc3a23
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:b83c089c7bf30e8ab65d519c3a465ed0798ca53fd07ffc47bf210169dda1a366
 | JobSpec :
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:889c6603b392cdbcf252a97889b14807dc1bc7b320fc71ca1a1ab1dcf76a7a12
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:c530e13d02354d0d76e2724fca7669fad7bae521b5f886a2a7e3a4fb1cce8dd1
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 | CronJob :
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:1bf6fca7cc5036804c83812fc9bbae6f5fac0e462328d18dbb1d6903258e36c8
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:a54e82e450036228d20ede8137d234ca5b1be08c36e426f8637909cecfe99154
 | CronJobList :
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:63e4ccbe79cd8fb418109e137cb90d89df6eb2fdf4e53780985f9a06bc13af01
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2abef70c1fa349ee511383af297495e954f2004f42dcded0117b363239f0edc6
 | CronJobSpec :
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:05300da941e48bb5bd67081bdb3e993528235a1d7f8948ba112ddbd3100b7f33
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:34f04d816146839ebbbf2b40ee821b841951082a2510085cff13b48fec30af92
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 | JobTemplateSpec :
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:959eee751ac9bdfffce59990061969d2509d4dfdf17fb8201825db239bf74bd4
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:dde76a9967501e8ebd29ead0776076ef513f6d631c5f5f47141774ca9cb7147c
 | CertificateSigningRequest :
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:ccb53f3c9720d799c9a280b23565de25ab1992b701d52ca6c8f8e7fa21fdb977
 | CertificateSigningRequestCondition :
@@ -449,11 +449,11 @@
 | PodStatus :
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:76800003e551406fea214c10166149b231668764a166a11579a1dcb8eac94d81
 | PodTemplate :
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:4076a1a0fdf2e4272f7921ed1ecf046cec4e71c15c738f938541476b884c42f6
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:e1a17029139b4a38a808f7f58600db7be1042aa6287e6e6b5823c87e39081a9b
 | PodTemplateList :
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:b2e45861cc05b3cecf61320937f628ce14e9ffdf3b02ff23aad2d475196e4505
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:eedf95a2ddb51f7f322678b9b299d5fae0a77a21c8226589fcc805a6f09f533c
 | PodTemplateSpec :
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:8eea21c0ace52dd3f671f41d6de30abdfb10ba05bf0b44f571472a6a6d689b1f
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:09352eb34dcecefa84e22b93423136bfd37f60b23b564bd6d2a29fd9abfa4e3f
 | PortworxVolumeSource :
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 | PreferredSchedulingTerm :
@@ -469,13 +469,13 @@
 | RBDVolumeSource :
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 | ReplicationController :
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:cd15e5d7af5ebc0aea08a47fb6ffccf40bc9f1dcb9e12070d03ccebe75fd86b7
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:cb1a847cd82fabcaf19114d3d3c8559d93eaade96721f2b66ee9161b6dd4f53d
 | ReplicationControllerCondition :
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicationControllerList :
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:a37322f3cc1a3e21dd963e5c747fb1feab94bab8a10a3c0a867be2feb89ad6d2
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:353186aaf8f8c66413d34bf07aaf03c2d11406d91e8865ac123a512116897f36
 | ReplicationControllerSpec :
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:996ac4204e547f4db3c40644affa7fc436f6ee84666012e316e40036b166129b
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:97d0a875908f491b593d1a4e5b648b05b62ea228565c13c4ebe9d814a7b142bf
 | ReplicationControllerStatus :
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | ResourceFieldSelector :

--- a/1.17/README.md
+++ b/1.17/README.md
@@ -53,7 +53,7 @@ In the following example, we:
 -- examples/deploymentSimple.dhall
 
 let kubernetes =
-      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:ef3845f617b91eaea1b7abb5bd62aeebffd04bcc592d82b7bd6b39dda5e5d545
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let deployment =
       kubernetes.Deployment::{
@@ -64,7 +64,7 @@ let deployment =
           }
         , replicas = Some 2
         , template = kubernetes.PodTemplateSpec::{
-          , metadata = kubernetes.ObjectMeta::{ name = Some "nginx" }
+          , metadata = Some kubernetes.ObjectMeta::{ name = Some "nginx" }
           , spec = Some kubernetes.PodSpec::{
             , containers =
               [ kubernetes.Container::{
@@ -148,7 +148,7 @@ let Prelude =
 let map = Prelude.List.map
 
 let kubernetes =
-      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:ef3845f617b91eaea1b7abb5bd62aeebffd04bcc592d82b7bd6b39dda5e5d545
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let Service = { name : Text, host : Text, version : Text }
 

--- a/1.17/defaults.dhall
+++ b/1.17/defaults.dhall
@@ -17,7 +17,7 @@
 , ControllerRevisionList =
     ./defaults/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:2343b690c1c4d49b5e1fe09da5a71fc9e8c74f2a9975764b0ad41cf597b6b616
 , DaemonSet =
-    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:9c2b82b4d9b61bf7de9ed063f67198be6ec6e38d6589210caa4ac442c542e83d
+    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:7e84a4861a5b40048e962d0ee1ccc07d4a870f424eaf6497f7db414ea5385cd9
 , DaemonSetCondition =
     ./defaults/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , DaemonSetList =
@@ -29,7 +29,7 @@
 , DaemonSetUpdateStrategy =
     ./defaults/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:0267659f9e8647bbf2e9f9073536c4c0c60b8ff1c076523cd7773b05e8d1c270
 , Deployment =
-    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:bc5d39541156f0890affabca1980bd390ba311dc96f719af6633e418a8befa70
+    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:dfc8c44b68fa3834d307b5d19922568b27bdf8947a39417a2a028c4f473c37ad
 , DeploymentCondition =
     ./defaults/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:006ebe956ae6e2918eb18beed3f6378d0f79437bfc449f4b6c7852206a7c7e5d
 , DeploymentList =
@@ -41,13 +41,13 @@
 , DeploymentStrategy =
     ./defaults/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:e5ba779274cb5a0b72069647e1aa8b257380ddb3b183aef45233028c399f65b9
 , ReplicaSet =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:d824c0006c7892cc3996ed0d51805a8cffe0da64dd440206c19095ae6873af7a
+    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:d952a5348c44febfe6f4926cdf9311c8b72ba314773a6b78052ec2f456a1b973
 , ReplicaSetCondition =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicaSetList =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:e57739bf261dfcdaec492632f1986b57c7d7bc45a4ba7be145beb64b739fe70f
 , ReplicaSetSpec =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:2b277eede16e00df6e6591bd097e33bd73c5db24a4b2e8dca9e01ce056915a05
+    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:8a924dfd2fc23e587fb04ad1b7de0d05eba8a94f90fc0f0a354a4c84672f8abe
 , ReplicaSetStatus =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , RollingUpdateDaemonSet =
@@ -57,7 +57,7 @@
 , RollingUpdateStatefulSetStrategy =
     ./defaults/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:4d9feb8034f9f58692aebeed06474c07c387e5b8bc11c40dc36ec6390a26fa63
 , StatefulSet =
-    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:32c92803bcb882be48429e70d50d97069511c270dfc05c516cefce426546fe37
+    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:e81c471c250ee2c42849e1a78b542020f96135fe36d4a91cd7603df6c3d0b87e
 , StatefulSetCondition =
     ./defaults/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , StatefulSetList =
@@ -167,7 +167,7 @@
 , ResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Job =
-    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:5c78479e53256aa59d2a4c1735561a923edd9a660050182a06967ca5d7748035
+    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:27ca3bcf46f7c29946a204f553bafa9efa66becf60befdb177054c74d66ec86a
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
 , JobList =
@@ -177,7 +177,7 @@
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall sha256:acf4f792ff1e56e53cb6d00ddc60f6ade85c44289efcbbfd2e5b81e1ac0347fc
 , CronJob =
-    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:be38e61d6ea5e5f46bdc46ae48787cb2a646f5d1d5bd38c92e12824def67a816
+    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:bafc51976af6a7fa2be45b03f9665aa02bd4206f289fe30b2a6a17636a49a94e
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:d6f792b6d1f5cc8e862708490973d8b46eeb2d7adf4f3be3170a93ce2b70be7a
 , CronJobSpec =
@@ -185,7 +185,7 @@
 , CronJobStatus =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:751a6c74f8753d8467f43f76bc3b0661655a65daf9f907f6f814f01ade0fcd70
 , JobTemplateSpec =
-    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:1211b8981368acd30b2d3eb5b31fb5726e1c043c3c833d10486327f4d64ab8da
+    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:6b523b171dcdc85569564988abf8b3b729c6c417384bdc9921ab2ae5c8f42ec1
 , CertificateSigningRequest =
     ./defaults/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:fc1ae5e4b43cbc3d6410fce82d6859e180c77ce5b9c643b2562588f85e1ab780
 , CertificateSigningRequestCondition =
@@ -449,11 +449,11 @@
 , PodStatus =
     ./defaults/io.k8s.api.core.v1.PodStatus.dhall sha256:1e5a1592d9c192d7d2021e9fde347019503a365372fe7c9b0af203477399a7ef
 , PodTemplate =
-    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:357fa8331c18f0ab168cd17e99f615c80a1a5602c229739a0263883c21190492
+    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:7ea50a8d94ddbec5e5fb9b99725a113fcc571588b5fb8c8ef6754cfb252ca07b
 , PodTemplateList =
     ./defaults/io.k8s.api.core.v1.PodTemplateList.dhall sha256:51ca93c255c7ab48ec42245f8b34a4effdd072cd019931f37ef304d8b46d6e6f
 , PodTemplateSpec =
-    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:4cabdcf0d97f7a1d52efd179d9bf7d0c2000565dad2d364b4037b1cae23faa89
+    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:f824d049f1e1e3f03e903d662b86355c60751b60724433c8c0fb4cffaf584f40
 , PortworxVolumeSource =
     ./defaults/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:5d8e73366d928941a81088f57aaf538a8c3a8d171086228dcefe3aa8084e6a0a
 , PreferredSchedulingTerm =
@@ -469,13 +469,13 @@
 , RBDVolumeSource =
     ./defaults/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:0c1b0c6ed400fe9c63c9a97d77d6d6a69463137e0e43687c4087b7e8cce747c3
 , ReplicationController =
-    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:2a0f96cef7575592868866dcc81cb86d4e14844c441c9749d8c51c0d0279827b
+    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:f58f6ba78c0f9d7bf7650cab3a513b5924ca7c4987e96e0565fc002b28715097
 , ReplicationControllerCondition =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicationControllerList =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:e7dcae86af1b284f62a6f26fe1e432a6a27a9fa5c3100acdad84794ac21ed769
 , ReplicationControllerSpec =
-    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:882a84d65a27349b3fa9f9c9c3f172543703d695f93164dd61aca2b9c83cdb01
+    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:d5c6a4589d1ad66024786a3ef0908c928f76f9edc7b719c186e9605d879dfbb6
 , ReplicationControllerStatus =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , ResourceFieldSelector =

--- a/1.17/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.17/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.17/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.17/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.17/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.17/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall
+}

--- a/1.17/examples/aws-iam-authenticator-chart.dhall
+++ b/1.17/examples/aws-iam-authenticator-chart.dhall
@@ -1,5 +1,5 @@
 let kubernetes =
-      ../package.dhall sha256:ef3845f617b91eaea1b7abb5bd62aeebffd04bcc592d82b7bd6b39dda5e5d545
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let release = "wintering-rodent"
 
@@ -26,7 +26,7 @@ in  kubernetes.DaemonSet::{
         , type = Some "RollingUpdate"
         }
       , template = kubernetes.PodTemplateSpec::{
-        , metadata = kubernetes.ObjectMeta::{
+        , metadata = Some kubernetes.ObjectMeta::{
           , name = Some name
           , annotations = Some
               (toMap { `scheduler.alpha.kubernetes.io/critical-pod` = "" })

--- a/1.17/examples/deployment.dhall
+++ b/1.17/examples/deployment.dhall
@@ -2,7 +2,7 @@ let Prelude =
       ../Prelude.dhall sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e
 
 let kubernetes =
-      ../package.dhall sha256:ef3845f617b91eaea1b7abb5bd62aeebffd04bcc592d82b7bd6b39dda5e5d545
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let deployment =
       kubernetes.Deployment::{
@@ -21,7 +21,7 @@ let deployment =
             }
           }
         , template = kubernetes.PodTemplateSpec::{
-          , metadata = kubernetes.ObjectMeta::{
+          , metadata = Some kubernetes.ObjectMeta::{
             , name = Some "nginx"
             , labels = Some (toMap { app = "nginx" })
             }

--- a/1.17/examples/deploymentSimple.dhall
+++ b/1.17/examples/deploymentSimple.dhall
@@ -1,5 +1,5 @@
 let kubernetes =
-      ../package.dhall sha256:ef3845f617b91eaea1b7abb5bd62aeebffd04bcc592d82b7bd6b39dda5e5d545
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let deployment =
       kubernetes.Deployment::{
@@ -10,7 +10,7 @@ let deployment =
           }
         , replicas = Some 2
         , template = kubernetes.PodTemplateSpec::{
-          , metadata = kubernetes.ObjectMeta::{ name = Some "nginx" }
+          , metadata = Some kubernetes.ObjectMeta::{ name = Some "nginx" }
           , spec = Some kubernetes.PodSpec::{
             , containers =
               [ kubernetes.Container::{

--- a/1.17/examples/ingress.dhall
+++ b/1.17/examples/ingress.dhall
@@ -4,7 +4,7 @@ let Prelude =
 let map = Prelude.List.map
 
 let kubernetes =
-      ../package.dhall sha256:ef3845f617b91eaea1b7abb5bd62aeebffd04bcc592d82b7bd6b39dda5e5d545
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let Service = { name : Text, host : Text, version : Text }
 

--- a/1.17/examples/service.dhall
+++ b/1.17/examples/service.dhall
@@ -2,7 +2,7 @@ let Prelude =
       ../Prelude.dhall sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e
 
 let kubernetes =
-      ../package.dhall sha256:ef3845f617b91eaea1b7abb5bd62aeebffd04bcc592d82b7bd6b39dda5e5d545
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let spec =
       { selector = Some (toMap { app = "nginx" })

--- a/1.17/package.dhall
+++ b/1.17/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:7af88fa1a08f6bfafac2a96caa417b924b84eddab589ea715a9d5f333803d771
+  ./schemas.dhall sha256:281397ce0cb33e90968b95af1d41d657d439e7d1111ca4591a72e61ad59bb08a
 ∧ { IntOrString =
-      ( ./types.dhall sha256:2b2ff76dda44fec4b227fa1a9d4eec83a6c532a3685f39636404f0d36b32bc90
+      ( ./types.dhall sha256:605e8657997266b7a6ab4c56d00bfae70e7f59d2347906914251b1db1072b055
       ).IntOrString
   , Resource =
-      ./typesUnion.dhall sha256:d7b8c9c574f3c894fa2bca9d9c2bec1fea972bb3acdde90e473bc2d6ee51b5b1
+      ./typesUnion.dhall sha256:bba98713ad73a76f155afd3f92d189b91097e0e6c9f64c4a35fcc60eeb68f199
   }

--- a/1.17/schemas.dhall
+++ b/1.17/schemas.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./schemas/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:139727b422a6c643c13a021400e75ed9df5bd955c86439c018a1bbb5ac51f802
 , DaemonSet =
-    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:5d815a3bd966899a87397e0dc8e7cd2841b094e7b17c019c06699efebd0dc8e7
+    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:a98f8369bf5a7fce3638e9cfb625f3407e80d901d899477ba8f58d9957fd1507
 , DaemonSetCondition =
     ./schemas/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , DaemonSetList =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:131a77baea0d738690321f5d456008e1fe7949e29d3fe385052fa17a5c3a9454
+    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:afe8d9d4791b15a04065146349114b8ba646cd859535fdda9b8df28a8c0f2e4d
 , DaemonSetSpec =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:a9d67d0d354bc3c825592deb0484f18e8adeecd2d771b43e37758ebc3fcc193b
+    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:74e592cf81c86f91e06def139a5881b3acdb01e4c0ac92cad29c984cc7f56871
 , DaemonSetStatus =
     ./schemas/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:a68e46f267e6a5071080338953f8b1d13dff20cbfc06ae4b25f7645ff0b6cff6
 , DaemonSetUpdateStrategy =
     ./schemas/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:3efad19fff60b45006bb76c1bb6bd872e33a62d006dc6c6cd699c5945342814a
 , Deployment =
-    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:ed698f94befbcf580a1556a9c0f4ef72b8769a335f6525e5b19097e391fc1702
+    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:6bfafb31e27a670958cafeed16a94f9f102f0e8cea64e79c4ff42bc99ca8f93f
 , DeploymentCondition =
     ./schemas/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:f6d653c489ad36f5ef1c422a5a8297e7e73b95210cc0e4224611c6188bad3fd5
 , DeploymentList =
-    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:fbff5c25e797a64dbba75b65f383ec1dcd02218cdcf94db08b31b5b76c1418b3
+    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:7e906a597249cb1879e94cb9544c896fee797e3d04dcc8c36f6ce196c82a91c3
 , DeploymentSpec =
-    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:54059b7e4786b471c8526cb72abf71f4135258c973b4e73149521c806a65117f
+    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:de800a9f105d05e727d5752d27b7070dbbf926e832ecbe929dfea159b331df83
 , DeploymentStatus =
     ./schemas/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:6c1a6f0ab5f98b0ae2aa9d861ea0ede60adbf94b1e21f0e2be39d6abe21bda39
 , DeploymentStrategy =
     ./schemas/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:f6893d857d85ff5bf089070c9a3416026483331e40c3999c52dc17d9a06bdecd
 , ReplicaSet =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:a444e529a8c9644c96a09d35177f9e1213b4be727c1b742dd28c8e2becb5934e
+    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:4201414c67b27cf8affb3a3add69d9fcf176726460e17869bed52bbd6891b4f1
 , ReplicaSetCondition =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicaSetList =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:b15e3afa6156a74c83a77a0d5db98495a0fac5f76f127f995a1db378c7613eae
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:5fc4425b1d8aff2677b6dc07190adde0536053f94e4e2bbe0432bd3e88706c44
 , ReplicaSetSpec =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:67333e3351ccdf0026902c1b135bfcb83f6b917fe2e1a43599678c2ddffd6a4b
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:460e737b0d110f5b57b6dd5203ef485416a0897feb0c31492e19c2ac6dc6640b
 , ReplicaSetStatus =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./schemas/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:0471cec7aab65313bb60ff3f774ee8d8c8e406f16b34f3dd27b50659055acecb
 , StatefulSet =
-    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:5e736bc483603e0fead8bf45af53c680555c619c61e9817b3ab8e50c371c4e1a
+    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:0f2db135a956a3d41b91920494f40541b534ba8208010b63c047f38f0dceaf17
 , StatefulSetCondition =
     ./schemas/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , StatefulSetList =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:97b9460b37a14cbc39deb917d1e83e9944861784e51453496ff17646cb8acadc
+    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:ea520cddad7c27491e44ade3e40770643efb305c81edde6bbab1997828cb160f
 , StatefulSetSpec =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:ef36289d738b94a68d13fd7be8a7334fd5b6244af92e42d81565bfdd7e1ac56b
+    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:43865c86843ec6369c45fb6c280905555a60b09296f7ea5f692c2f5ce045c6cc
 , StatefulSetStatus =
     ./schemas/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:a490d193b72e53cbb9b1fe35dde9bc02415e3f01bf8ce8a516ddbad25855df42
 , StatefulSetUpdateStrategy =
@@ -167,25 +167,25 @@
 , ResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , Job =
-    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:d9d53376574d04c578507abd96f0e12c73845d4851cba851180300d180b0951c
+    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:ced8121d45ddf417ced464f1fb38cd14a153bc8fca47cc23ccbf5ae13be0ace8
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
-    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:df74c374c24dd01cd338892fcdcdb80964246f7c11e452fb8367610b4ae8117e
+    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:2ce99dbb14d0eb0fca9c1cc9539bbaa9ddc81e44f201e0198ee9960b769cb29b
 , JobSpec =
-    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:de6a0b5a1eeed221345f056e15c8c63acfa4ce695eef1eb37dc79d1d6e449be3
+    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:557f3eb178aaa95a6e28cda2df0b15adb40ed8c1df3086aafb106242f60d6d94
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall sha256:ddbf73e9d4be060bdfb9aabc84c1ad30860a6ac6b37fcdbff7bbae8e473a33c1
 , CronJob =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:1c123d52f3a3cdb08a1f48f7e877536a0d1aa660f1c9f13823d531b111fbb1ff
+    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:3617bf893f1943bcfd057900582ca5fcaed3941a03602d7bf104612d73ec83db
 , CronJobList =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2127dbe9f1e48d3bc3bc312402b7b3bda0877e203e46d13555f1fa80d5f94313
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:513362f795f3981604de48833466783de151afbf2f536a3fda7653b2f210f1e6
 , CronJobSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:6679ca5c5b62ac38d1644dd7846b2b87a558fe268d014f0cd12fd4639cbdef16
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:46000e81129aab5db7d1f431f89be99a63f3a91914b23f51bbebb4de76c0b396
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:aaef515cade329c5c1bccb54d90e32c20c3b7bcb96ffdee38650292cf56c10d4
 , JobTemplateSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:0d54598c4445dd179b95fc5e27c55035c0a7488edac46cfed897a97ef694e9ee
+    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:f977128acbb9dee2b7e3cd34cc1c7d6f7ff0e6b87695b6ce2bbbc3d8b244c688
 , CertificateSigningRequest =
     ./schemas/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:8da55ca2b6f4a03970fe6edc1f75666ec6064ce61141fa3296c7231fe74f035b
 , CertificateSigningRequestCondition =
@@ -449,11 +449,11 @@
 , PodStatus =
     ./schemas/io.k8s.api.core.v1.PodStatus.dhall sha256:bca3d68a0c9b023f53c79aa7cea5e3d5181fd460adf03d0732f60edf82e845fe
 , PodTemplate =
-    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:8a3569e1b3b0bc4d455c3d543317ab5a4bb725e1c4d8993b4de9658f2af38bdd
+    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:d0436a8fe4eb82527320a7a00306a92a4884cc1d7ed3750fa3e458e90eeeda33
 , PodTemplateList =
-    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:12f302efe97b1b40217fabc4b653035359a9d7aedf1f1b667def58e87499eeb6
+    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:8b7bde124eaecc9e0f531675e0be8290e13b630e3fdce7b6b278c83bc86c4bab
 , PodTemplateSpec =
-    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:75c14c8d571e9a997314df9f56bd19df6ac2e60663a87aa9ab44b5e620da06a7
+    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:9c406f98ae7ebbc539ce838e5c4866eb15c20f48ed9025d300b1cc59dddccd3b
 , PortworxVolumeSource =
     ./schemas/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:b0bf02de5706c9f17b2dfb7f5938941151708cffc2bf1e4c69ca4a9ed1e4b735
 , PreferredSchedulingTerm =
@@ -469,13 +469,13 @@
 , RBDVolumeSource =
     ./schemas/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:ac07443af1c9f57e0175d9468507c2259feee9ea807f71ba4f5383658d62cd36
 , ReplicationController =
-    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:e08820db40bad5895437dafd248e7f85f5919da4a07b638e5dae168011951785
+    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:5684789e2d015eb77100370822874391dd102999a9fbd5c548a0b60032e56e3e
 , ReplicationControllerCondition =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicationControllerList =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:15169144ab38df6b4f44691ccf74a5d746dc878dfb2d1d07816e0c754eb0a836
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:cfe3c12ff92308d8e836c7c7ef541a762c50e047c8ff43273d42a244573796c2
 , ReplicationControllerSpec =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:a256090fbd1d0570f7f649424bc8458bea0c826c947d04b6df7f0e02f3f0fe00
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:2a6cdb0600e8d966baa0f093eac3b1fd8fd69834051ea9d37d9955487f838754
 , ReplicationControllerStatus =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , ResourceFieldSelector =

--- a/1.17/types.dhall
+++ b/1.17/types.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:209723e7a750dc2b67fb355e9847f70439fecc3d68e97ae2d20d9b0f33f1c643
 , DaemonSet =
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:0fa760b6fc3995c392036494d484eba95f85e74a470eb7e3463147ae8fb8b646
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:e46d62a02728158d09b6a205ef02f987b282acf366fafda9ff27017be4f8cea2
 , DaemonSetCondition =
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , DaemonSetList =
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:350c6e2a0e6f421d995d80fcad1628ed5c1e5445408534091a2262bca1534a02
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:672559b89b2f8ae28cd9e313131128b99ad7b4b912d7171f139985923cd95f0d
 , DaemonSetSpec =
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:f653e781d6af8a93e56c5134f1a698d9512d74d626acc53d66bfa60895c452cc
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:a15bc4d1fa7c70f88c9aaeb4ad076087918dde32a3461071bcd02740c40b44d6
 , DaemonSetStatus =
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 , DaemonSetUpdateStrategy =
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 , Deployment =
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:d151757b70d96a465afd0edbe49f493aee9a2671d2a52166535f46c3468d4c1a
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:46bd74ccf0e6c6a5c3b71f271f8417de954c06c0c82b80664731e5b8b50bb8d8
 , DeploymentCondition =
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 , DeploymentList =
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:0bcfbf8a0cc54cb8b7ca0947969b94c8a0b01d8f32c225e3e988804390177dd8
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:1a2ad78552ff0c7bdfc8b50a2e03738a9f2bc917409a19899667a1c1ee2c4a20
 , DeploymentSpec =
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:1aa0e0d14a7b2932a29529a2297f245555fe68e9131cdbc5e19be401c34eb19d
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:10c07527edf1662a7c9109f948ebc7dd2389800638b029b405ef29eeafa106b2
 , DeploymentStatus =
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 , DeploymentStrategy =
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 , ReplicaSet =
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:b4342465f4b1cc36d2174a30e3a6cf448a763d8d0fdcf4b1fd662345397d58d7
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:4c427eb8762cb3a481c2f76041f18d48783567f652b6cfd1cef310827b4c43c6
 , ReplicaSetCondition =
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicaSetList =
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:5bc6183e381ff2dadefed4283b570de07dd7a836bbb74fa3dbc588c926ca9492
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:ed4a3f0d31b29d076200f32994dde29a040af4c95b2d7c23cbaaf273531b678b
 , ReplicaSetSpec =
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:61175713ff8861c718e5ae9f4c548ec9e820438f25b1cf197bc80196ae73cfed
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:e7038dd29d1f1c42c6e5232e559286eb25e26a642be58f524cda35498ca154cb
 , ReplicaSetStatus =
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 , StatefulSet =
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:6ffeb8022959eadf48afe0da1095d9ab2844f740937898eed4486308331b6b13
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:ddaed92c80451da9f167395975815b66484611c0dcc0a38d6d7098fef0184403
 , StatefulSetCondition =
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , StatefulSetList =
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:ce8f44a55a45992e315cfc978c1196ab121d3b61c91f9000402b7a896a43b249
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:4fb9bcd2e600851cff7758024177253a141c0baf541a9ee5c05537edf91dbce4
 , StatefulSetSpec =
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:d4a6c6ad0c1ac7bf9fbc2c51b9fb92fcfef170ce9b9e4477c32ef66f85bc7406
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:794f83ce9e9074e4df43cb26ea36a9dcb65769c613f9ddd6293c7e814d9131af
 , StatefulSetStatus =
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 , StatefulSetUpdateStrategy =
@@ -167,25 +167,25 @@
 , ResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , Job =
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:830e84490c63b021a1ea2a3cd4aa17e421e5d8578324472ed94f3cc0d18c2032
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:e1f71eaac731107357dff30094a05e285f521daae62643ec01296b4cc5ff7627
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:517b576e15724c01fa49dc1f4e4f8e70cb6cbb5daf5a2cfa7fcc1d48b4fc3a23
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:b83c089c7bf30e8ab65d519c3a465ed0798ca53fd07ffc47bf210169dda1a366
 , JobSpec =
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:889c6603b392cdbcf252a97889b14807dc1bc7b320fc71ca1a1ab1dcf76a7a12
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:c530e13d02354d0d76e2724fca7669fad7bae521b5f886a2a7e3a4fb1cce8dd1
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 , CronJob =
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:1bf6fca7cc5036804c83812fc9bbae6f5fac0e462328d18dbb1d6903258e36c8
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:a54e82e450036228d20ede8137d234ca5b1be08c36e426f8637909cecfe99154
 , CronJobList =
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:63e4ccbe79cd8fb418109e137cb90d89df6eb2fdf4e53780985f9a06bc13af01
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2abef70c1fa349ee511383af297495e954f2004f42dcded0117b363239f0edc6
 , CronJobSpec =
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:05300da941e48bb5bd67081bdb3e993528235a1d7f8948ba112ddbd3100b7f33
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:34f04d816146839ebbbf2b40ee821b841951082a2510085cff13b48fec30af92
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 , JobTemplateSpec =
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:959eee751ac9bdfffce59990061969d2509d4dfdf17fb8201825db239bf74bd4
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:dde76a9967501e8ebd29ead0776076ef513f6d631c5f5f47141774ca9cb7147c
 , CertificateSigningRequest =
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:ccb53f3c9720d799c9a280b23565de25ab1992b701d52ca6c8f8e7fa21fdb977
 , CertificateSigningRequestCondition =
@@ -449,11 +449,11 @@
 , PodStatus =
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:76800003e551406fea214c10166149b231668764a166a11579a1dcb8eac94d81
 , PodTemplate =
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:4076a1a0fdf2e4272f7921ed1ecf046cec4e71c15c738f938541476b884c42f6
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:e1a17029139b4a38a808f7f58600db7be1042aa6287e6e6b5823c87e39081a9b
 , PodTemplateList =
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:b2e45861cc05b3cecf61320937f628ce14e9ffdf3b02ff23aad2d475196e4505
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:eedf95a2ddb51f7f322678b9b299d5fae0a77a21c8226589fcc805a6f09f533c
 , PodTemplateSpec =
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:8eea21c0ace52dd3f671f41d6de30abdfb10ba05bf0b44f571472a6a6d689b1f
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:09352eb34dcecefa84e22b93423136bfd37f60b23b564bd6d2a29fd9abfa4e3f
 , PortworxVolumeSource =
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 , PreferredSchedulingTerm =
@@ -469,13 +469,13 @@
 , RBDVolumeSource =
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 , ReplicationController =
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:cd15e5d7af5ebc0aea08a47fb6ffccf40bc9f1dcb9e12070d03ccebe75fd86b7
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:cb1a847cd82fabcaf19114d3d3c8559d93eaade96721f2b66ee9161b6dd4f53d
 , ReplicationControllerCondition =
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicationControllerList =
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:a37322f3cc1a3e21dd963e5c747fb1feab94bab8a10a3c0a867be2feb89ad6d2
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:353186aaf8f8c66413d34bf07aaf03c2d11406d91e8865ac123a512116897f36
 , ReplicationControllerSpec =
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:996ac4204e547f4db3c40644affa7fc436f6ee84666012e316e40036b166129b
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:97d0a875908f491b593d1a4e5b648b05b62ea228565c13c4ebe9d814a7b142bf
 , ReplicationControllerStatus =
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , ResourceFieldSelector =

--- a/1.17/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.17/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.17/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.17/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.17/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.17/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.core.v1.PodSpec.dhall
 }

--- a/1.17/typesUnion.dhall
+++ b/1.17/typesUnion.dhall
@@ -17,37 +17,37 @@
 | ControllerRevisionList :
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:209723e7a750dc2b67fb355e9847f70439fecc3d68e97ae2d20d9b0f33f1c643
 | DaemonSet :
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:0fa760b6fc3995c392036494d484eba95f85e74a470eb7e3463147ae8fb8b646
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:e46d62a02728158d09b6a205ef02f987b282acf366fafda9ff27017be4f8cea2
 | DaemonSetCondition :
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | DaemonSetList :
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:350c6e2a0e6f421d995d80fcad1628ed5c1e5445408534091a2262bca1534a02
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:672559b89b2f8ae28cd9e313131128b99ad7b4b912d7171f139985923cd95f0d
 | DaemonSetSpec :
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:f653e781d6af8a93e56c5134f1a698d9512d74d626acc53d66bfa60895c452cc
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:a15bc4d1fa7c70f88c9aaeb4ad076087918dde32a3461071bcd02740c40b44d6
 | DaemonSetStatus :
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 | DaemonSetUpdateStrategy :
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 | Deployment :
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:d151757b70d96a465afd0edbe49f493aee9a2671d2a52166535f46c3468d4c1a
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:46bd74ccf0e6c6a5c3b71f271f8417de954c06c0c82b80664731e5b8b50bb8d8
 | DeploymentCondition :
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 | DeploymentList :
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:0bcfbf8a0cc54cb8b7ca0947969b94c8a0b01d8f32c225e3e988804390177dd8
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:1a2ad78552ff0c7bdfc8b50a2e03738a9f2bc917409a19899667a1c1ee2c4a20
 | DeploymentSpec :
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:1aa0e0d14a7b2932a29529a2297f245555fe68e9131cdbc5e19be401c34eb19d
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:10c07527edf1662a7c9109f948ebc7dd2389800638b029b405ef29eeafa106b2
 | DeploymentStatus :
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 | DeploymentStrategy :
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 | ReplicaSet :
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:b4342465f4b1cc36d2174a30e3a6cf448a763d8d0fdcf4b1fd662345397d58d7
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:4c427eb8762cb3a481c2f76041f18d48783567f652b6cfd1cef310827b4c43c6
 | ReplicaSetCondition :
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicaSetList :
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:5bc6183e381ff2dadefed4283b570de07dd7a836bbb74fa3dbc588c926ca9492
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:ed4a3f0d31b29d076200f32994dde29a040af4c95b2d7c23cbaaf273531b678b
 | ReplicaSetSpec :
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:61175713ff8861c718e5ae9f4c548ec9e820438f25b1cf197bc80196ae73cfed
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:e7038dd29d1f1c42c6e5232e559286eb25e26a642be58f524cda35498ca154cb
 | ReplicaSetStatus :
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | RollingUpdateDaemonSet :
@@ -57,13 +57,13 @@
 | RollingUpdateStatefulSetStrategy :
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 | StatefulSet :
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:6ffeb8022959eadf48afe0da1095d9ab2844f740937898eed4486308331b6b13
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:ddaed92c80451da9f167395975815b66484611c0dcc0a38d6d7098fef0184403
 | StatefulSetCondition :
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | StatefulSetList :
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:ce8f44a55a45992e315cfc978c1196ab121d3b61c91f9000402b7a896a43b249
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:4fb9bcd2e600851cff7758024177253a141c0baf541a9ee5c05537edf91dbce4
 | StatefulSetSpec :
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:d4a6c6ad0c1ac7bf9fbc2c51b9fb92fcfef170ce9b9e4477c32ef66f85bc7406
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:794f83ce9e9074e4df43cb26ea36a9dcb65769c613f9ddd6293c7e814d9131af
 | StatefulSetStatus :
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 | StatefulSetUpdateStrategy :
@@ -167,25 +167,25 @@
 | ResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | Job :
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:830e84490c63b021a1ea2a3cd4aa17e421e5d8578324472ed94f3cc0d18c2032
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:e1f71eaac731107357dff30094a05e285f521daae62643ec01296b4cc5ff7627
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:517b576e15724c01fa49dc1f4e4f8e70cb6cbb5daf5a2cfa7fcc1d48b4fc3a23
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:b83c089c7bf30e8ab65d519c3a465ed0798ca53fd07ffc47bf210169dda1a366
 | JobSpec :
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:889c6603b392cdbcf252a97889b14807dc1bc7b320fc71ca1a1ab1dcf76a7a12
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:c530e13d02354d0d76e2724fca7669fad7bae521b5f886a2a7e3a4fb1cce8dd1
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 | CronJob :
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:1bf6fca7cc5036804c83812fc9bbae6f5fac0e462328d18dbb1d6903258e36c8
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:a54e82e450036228d20ede8137d234ca5b1be08c36e426f8637909cecfe99154
 | CronJobList :
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:63e4ccbe79cd8fb418109e137cb90d89df6eb2fdf4e53780985f9a06bc13af01
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2abef70c1fa349ee511383af297495e954f2004f42dcded0117b363239f0edc6
 | CronJobSpec :
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:05300da941e48bb5bd67081bdb3e993528235a1d7f8948ba112ddbd3100b7f33
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:34f04d816146839ebbbf2b40ee821b841951082a2510085cff13b48fec30af92
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 | JobTemplateSpec :
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:959eee751ac9bdfffce59990061969d2509d4dfdf17fb8201825db239bf74bd4
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:dde76a9967501e8ebd29ead0776076ef513f6d631c5f5f47141774ca9cb7147c
 | CertificateSigningRequest :
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:ccb53f3c9720d799c9a280b23565de25ab1992b701d52ca6c8f8e7fa21fdb977
 | CertificateSigningRequestCondition :
@@ -449,11 +449,11 @@
 | PodStatus :
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:76800003e551406fea214c10166149b231668764a166a11579a1dcb8eac94d81
 | PodTemplate :
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:4076a1a0fdf2e4272f7921ed1ecf046cec4e71c15c738f938541476b884c42f6
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:e1a17029139b4a38a808f7f58600db7be1042aa6287e6e6b5823c87e39081a9b
 | PodTemplateList :
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:b2e45861cc05b3cecf61320937f628ce14e9ffdf3b02ff23aad2d475196e4505
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:eedf95a2ddb51f7f322678b9b299d5fae0a77a21c8226589fcc805a6f09f533c
 | PodTemplateSpec :
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:8eea21c0ace52dd3f671f41d6de30abdfb10ba05bf0b44f571472a6a6d689b1f
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:09352eb34dcecefa84e22b93423136bfd37f60b23b564bd6d2a29fd9abfa4e3f
 | PortworxVolumeSource :
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 | PreferredSchedulingTerm :
@@ -469,13 +469,13 @@
 | RBDVolumeSource :
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 | ReplicationController :
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:cd15e5d7af5ebc0aea08a47fb6ffccf40bc9f1dcb9e12070d03ccebe75fd86b7
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:cb1a847cd82fabcaf19114d3d3c8559d93eaade96721f2b66ee9161b6dd4f53d
 | ReplicationControllerCondition :
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicationControllerList :
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:a37322f3cc1a3e21dd963e5c747fb1feab94bab8a10a3c0a867be2feb89ad6d2
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:353186aaf8f8c66413d34bf07aaf03c2d11406d91e8865ac123a512116897f36
 | ReplicationControllerSpec :
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:996ac4204e547f4db3c40644affa7fc436f6ee84666012e316e40036b166129b
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:97d0a875908f491b593d1a4e5b648b05b62ea228565c13c4ebe9d814a7b142bf
 | ReplicationControllerStatus :
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | ResourceFieldSelector :

--- a/1.18/defaults.dhall
+++ b/1.18/defaults.dhall
@@ -17,7 +17,7 @@
 , ControllerRevisionList =
     ./defaults/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:2343b690c1c4d49b5e1fe09da5a71fc9e8c74f2a9975764b0ad41cf597b6b616
 , DaemonSet =
-    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:87f35c2fb968fe67ac207c70b4a59e5f397a19272f6e16c6d3e3c61e7518d18a
+    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:356fd5b7ef140a3635f14c0a2c55e3b193cfbadc1363d0af30ca9a9c0e300773
 , DaemonSetCondition =
     ./defaults/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , DaemonSetList =
@@ -29,7 +29,7 @@
 , DaemonSetUpdateStrategy =
     ./defaults/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:0267659f9e8647bbf2e9f9073536c4c0c60b8ff1c076523cd7773b05e8d1c270
 , Deployment =
-    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:e182f5a0b9ff02bfbfbfb1cb21d76e89602074b23ee7261a862b8b80799cb8e3
+    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:3ea5b1c88704557a077feebd8c0b45f26b09e55730e2b2427c4f6f0ae46e5f7a
 , DeploymentCondition =
     ./defaults/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:006ebe956ae6e2918eb18beed3f6378d0f79437bfc449f4b6c7852206a7c7e5d
 , DeploymentList =
@@ -41,13 +41,13 @@
 , DeploymentStrategy =
     ./defaults/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:e5ba779274cb5a0b72069647e1aa8b257380ddb3b183aef45233028c399f65b9
 , ReplicaSet =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:3cafe382f9d0261f22a79e761ffa69ceee88d757e06c40ea73ff53cb6fdbadfa
+    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:25f1b9030fb507c14e74ae542761bbd18039a997f5c02eea517cd0828fb84194
 , ReplicaSetCondition =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicaSetList =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:e57739bf261dfcdaec492632f1986b57c7d7bc45a4ba7be145beb64b739fe70f
 , ReplicaSetSpec =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:9aad2d5b2e81eca15b2b7c9f69c60ec1230ed3d7390af6e5c813deb441eeabba
+    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:55d67178c15fc7d5c3d1c12b46d3fa082ce78fe9466b3285bd4d4033fc44e485
 , ReplicaSetStatus =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , RollingUpdateDaemonSet =
@@ -57,7 +57,7 @@
 , RollingUpdateStatefulSetStrategy =
     ./defaults/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:4d9feb8034f9f58692aebeed06474c07c387e5b8bc11c40dc36ec6390a26fa63
 , StatefulSet =
-    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:96396873908a88024331a0ef8c72bbee018a7537fc7474310e5665aec1f6f737
+    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:20084b79dd2fd1040a0868f5f6d9373d570f115f86721c183c8ed6b864592079
 , StatefulSetCondition =
     ./defaults/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , StatefulSetList =
@@ -173,7 +173,7 @@
 , ResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Job =
-    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:b8acb8ecee142bc03e1a7846ac8ff35fc7b44628d2727f66033569a099efaa73
+    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:5641e0c6429b852fe6fcd4850a69ca968e491bd8321ed2bc5bb6e9606c664bf1
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
 , JobList =
@@ -183,7 +183,7 @@
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall sha256:acf4f792ff1e56e53cb6d00ddc60f6ade85c44289efcbbfd2e5b81e1ac0347fc
 , CronJob =
-    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:75c5d9c98b6961a92ad0ca5794e322ab389d8bcebf0cfbb7b28592d5e15eaa96
+    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:40bca7cb724cc6f214ad7d33d86134048008ab61e6e1176d1a2fb8d88decec7a
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:d6f792b6d1f5cc8e862708490973d8b46eeb2d7adf4f3be3170a93ce2b70be7a
 , CronJobSpec =
@@ -191,7 +191,7 @@
 , CronJobStatus =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:751a6c74f8753d8467f43f76bc3b0661655a65daf9f907f6f814f01ade0fcd70
 , JobTemplateSpec =
-    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:4f61bd6d14b5e5074974bbc375e5868241cfda5870d7bff393a458ae1c077737
+    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:9a7dc75064d71179d55aecf4b3bbe5a20e702fc03304d77b9793483b8eb5a005
 , CertificateSigningRequest =
     ./defaults/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:23603d5bf2479840bea6f0a796fd2caab1d24174bff2f754f700854ad9ee0d12
 , CertificateSigningRequestCondition =
@@ -455,11 +455,11 @@
 , PodStatus =
     ./defaults/io.k8s.api.core.v1.PodStatus.dhall sha256:1e5a1592d9c192d7d2021e9fde347019503a365372fe7c9b0af203477399a7ef
 , PodTemplate =
-    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:1602974177378c27008efddf9146ee32609f51f778bcbb2a20831df46b10cbaf
+    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:3b7b59d0f3dd56ac4f25213c7177fa9c52c4ee000a110bfe9dbddf3768d50f8d
 , PodTemplateList =
     ./defaults/io.k8s.api.core.v1.PodTemplateList.dhall sha256:51ca93c255c7ab48ec42245f8b34a4effdd072cd019931f37ef304d8b46d6e6f
 , PodTemplateSpec =
-    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:04d05e87be25894546a581a06d49e8ecab5658573dd7dc12db5ab15a3a46cde4
+    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:f79dd8a9d33beeeaf76d5abecca978e05c24a67fec458712746d558ffb43c8c1
 , PortworxVolumeSource =
     ./defaults/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:5d8e73366d928941a81088f57aaf538a8c3a8d171086228dcefe3aa8084e6a0a
 , PreferredSchedulingTerm =
@@ -475,13 +475,13 @@
 , RBDVolumeSource =
     ./defaults/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:0c1b0c6ed400fe9c63c9a97d77d6d6a69463137e0e43687c4087b7e8cce747c3
 , ReplicationController =
-    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:ce9d036ed545bbfdd3a54ec6ed6754cca4861f0a92e0757d20b84de6cc73108a
+    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:71843994d8415d9557a83e47567773a003e9d869be31da3b83535c1873e51766
 , ReplicationControllerCondition =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicationControllerList =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:e7dcae86af1b284f62a6f26fe1e432a6a27a9fa5c3100acdad84794ac21ed769
 , ReplicationControllerSpec =
-    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:fda7a35d98b3d24fcd644cc08915b09078c6a2843f438e5aed4f6f14786e6016
+    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:b850cc44156015684d6041bfbbba5cca70a726bf51fca5074a7de1bbaabc1166
 , ReplicationControllerStatus =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , ResourceFieldSelector =

--- a/1.18/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.18/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.18/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.18/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.18/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.18/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall
+}

--- a/1.18/package.dhall
+++ b/1.18/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:10ef4d6e42e875ab6e62762401a055fbd2cd4eae6fea1aade139f73b9d4e7829
+  ./schemas.dhall sha256:3bef0f9f1f7e421312dae40276715afcea59a043267292eb7817e10afe15a1bd
 ∧ { IntOrString =
-      ( ./types.dhall sha256:b995d71b5750d1b8c38c50e2d683b7fc8af0d37f668f56b96089fdf4e483c7eb
+      ( ./types.dhall sha256:00ac0c343916265d4ec8cb2b52d55ff0250fae2d9e4ceb6bc498db2be253b3de
       ).IntOrString
   , Resource =
-      ./typesUnion.dhall sha256:c53ad6e5b9d6ff7d4e7ce7e7ada3ecb23282042311281e5d45b81f0f0d0ae7e8
+      ./typesUnion.dhall sha256:c894aef64db8ee2f75885e8533565d691f78b73f3797572498f136f5fa7b744c
   }

--- a/1.18/schemas.dhall
+++ b/1.18/schemas.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./schemas/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:139727b422a6c643c13a021400e75ed9df5bd955c86439c018a1bbb5ac51f802
 , DaemonSet =
-    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:5669f76754d284313af9774bbcbc637b37ea70e86c970efa3b3d4bf223e7fea7
+    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:d4611defd220fd2e506556c8784e058adb912696b49e09dd0782b98fc60b5c32
 , DaemonSetCondition =
     ./schemas/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , DaemonSetList =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:70147f8b637c9263647bf7b68ae45cadcec9ae63f86cbaea89c42c129ec6d934
+    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:f573fb67390be2170ecbe032f74b79df6a82346b2e78ba6f4a3fed3826b8675b
 , DaemonSetSpec =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:9a1359f32de34bb85f77790530fe8d1fef7103306d9d20cd15a703c8e0fe98e7
+    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:ed8d14e0cf98830d40f7f26b7b53a996055436f867f12009121116b7dedd0bca
 , DaemonSetStatus =
     ./schemas/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:a68e46f267e6a5071080338953f8b1d13dff20cbfc06ae4b25f7645ff0b6cff6
 , DaemonSetUpdateStrategy =
     ./schemas/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:3efad19fff60b45006bb76c1bb6bd872e33a62d006dc6c6cd699c5945342814a
 , Deployment =
-    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:b587dc6e6e604f9a18c9daeee0d5982d7e4a64b1e759f8de3ae7a789e497f40a
+    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:1539235e8cb7bfa3b6df4178396295616e462f15145e0a42d93de35fa20a9fd9
 , DeploymentCondition =
     ./schemas/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:f6d653c489ad36f5ef1c422a5a8297e7e73b95210cc0e4224611c6188bad3fd5
 , DeploymentList =
-    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:af5c40d9bde0141ab40090e426ad32903e1ec0afc8fcd50d443564b893329eb8
+    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:9f60dc8f0078f9b91ca493e13ec935adc09839d6b4cd9c53d1427ca55d518061
 , DeploymentSpec =
-    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:df92aa4335effdc55481f89f47fd1145b7478c6d84e3502ef1d5dd30b09f4361
+    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:5ee1fdbaf04d61438d1bfb52aef6c5548a7fd0c588d4a6c30b9986a77f9e39f2
 , DeploymentStatus =
     ./schemas/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:6c1a6f0ab5f98b0ae2aa9d861ea0ede60adbf94b1e21f0e2be39d6abe21bda39
 , DeploymentStrategy =
     ./schemas/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:f6893d857d85ff5bf089070c9a3416026483331e40c3999c52dc17d9a06bdecd
 , ReplicaSet =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:3732e8da3e90731ebc423b2620a29e2d6db95aaf141708687b5b177727b5efd6
+    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:957cfd7d1872942e049dbce4482b27802f1819df0e5330573ed50a2d9525d4fc
 , ReplicaSetCondition =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicaSetList =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:aea34cfc62dea18cd9ea6a9aa8d619dad7a66f79d79ed69502723f92acb56486
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:dfbe3c1e65c01049fad8ed42169ef7c727abde35bede1818a6b3c723cd807510
 , ReplicaSetSpec =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:f7effb1bc48f45328032be2a851f88aa3cab99ac3f1876c603ecc4575e3c01c0
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:bb599eeb0d72508a9059f12a1c93cf5d8e47cadc4f5f0b4e2e7370aa0aa946c0
 , ReplicaSetStatus =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./schemas/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:0471cec7aab65313bb60ff3f774ee8d8c8e406f16b34f3dd27b50659055acecb
 , StatefulSet =
-    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:81968deb7f40b951d5ea01ecd15d2acd857a0782300a4e345ccbd9f120d607b3
+    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:0e25b4cc22ee1aca72e715303004eeee48921ae2b476c61f1e286627971fc55e
 , StatefulSetCondition =
     ./schemas/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , StatefulSetList =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:3e0e4d675cd50e13b5da9f91c8ea3774cb0ba2ba52be18eb1e156b11cbed92a6
+    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:48f1aeef25503994e24a2b1cfa3b8d85cae6d1b464795377f8e6669e7251601c
 , StatefulSetSpec =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:38f9cfa74aa690e546fba27bd9f23bb6c245bc16a9e3e5864402718e14b9ed55
+    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:ebfda10b518d0eea7f8422d3fbd1992a3dfb81ec1b53f7d56204a7293d687214
 , StatefulSetStatus =
     ./schemas/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:a490d193b72e53cbb9b1fe35dde9bc02415e3f01bf8ce8a516ddbad25855df42
 , StatefulSetUpdateStrategy =
@@ -173,25 +173,25 @@
 , ResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , Job =
-    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:d8bf3b8050218a1da3f950c48d70b7647534b8760b072127ec00d11305aea929
+    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:0f5b3e54d9eba7f2ba037542d72fbd86cee45e70eda7df0380c7674620b5dbff
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
-    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:8d7025cc4c4d5b8c9482532dbc865a7d39df8fb7f4dcd04bb5b421c1c36e0085
+    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:4aed6bddbfce501ddcd42221b6fd10cb136123823683ac8985a7b7b7589d1411
 , JobSpec =
-    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:e91c81110b9da298f548781c4aef8d744aaf20b8966ab2d7ec77e5dccc6fecdc
+    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:7f9998c57b19a079095cb28d3456f9ea7a9a28f1160653994de4cb155df3ab35
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall sha256:ddbf73e9d4be060bdfb9aabc84c1ad30860a6ac6b37fcdbff7bbae8e473a33c1
 , CronJob =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:64aba96754737cfa700cafce4f15be3d8cb3e222edf92fcae5ed935bfb58b003
+    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:45cdffa260ffa61bc1a48936726b6ff84656250217dc2dc756a3128182f59aba
 , CronJobList =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:81ebc36c702c7ff2c42ec7c517bef265a9cedefeba4d8c55528472a085890ba5
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:0f519d53139ee9c535c46ffd667795149681a8d34e6ced982b4131bae1a37c97
 , CronJobSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:835306c7f0a787a7f4783346127dd656768fd9ad9d45b504684fd0c3258aeffd
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:d0cb7190acfb0bb731143857e893b3abca9e1b70a20ffc7b29e189e3f4d6f82b
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:aaef515cade329c5c1bccb54d90e32c20c3b7bcb96ffdee38650292cf56c10d4
 , JobTemplateSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:2d34a809ea318bf2efc6f891fd981a70c7185f5a28a61851c2cd75b2e2593b13
+    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:e69f78ff71d52279135f96e5f44641323d0d773556217352571885f56cd8ae88
 , CertificateSigningRequest =
     ./schemas/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:9121c0f38fda37c94c5eb339746f41d5da70ab7f1c834bca9b879b4922c67549
 , CertificateSigningRequestCondition =
@@ -455,11 +455,11 @@
 , PodStatus =
     ./schemas/io.k8s.api.core.v1.PodStatus.dhall sha256:bca3d68a0c9b023f53c79aa7cea5e3d5181fd460adf03d0732f60edf82e845fe
 , PodTemplate =
-    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:8bccae9b120495fe3afaa6f429eeef168866ba17fff780b87b5b1ab5d9308ff4
+    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:10d00721da40f7e75adba1ba16a20d958e560d9683d2904281f7457e36e2bd14
 , PodTemplateList =
-    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:5805677528fdae2594321f0ec705d81ebda15551e3b7afc4de0faedfb822e467
+    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:c7b66fde2037c087d736d641a65b91fcdb2bb6f43411d8fe42c93c6259af6428
 , PodTemplateSpec =
-    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:f4c28dea335410bdc8422e5cc40fa39c21574ee9800c391acca65e951e289ee0
+    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:6309698d505a7d0230567fdc98de2a37c0ec0884f1fc6bb2b80bfc4165547049
 , PortworxVolumeSource =
     ./schemas/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:b0bf02de5706c9f17b2dfb7f5938941151708cffc2bf1e4c69ca4a9ed1e4b735
 , PreferredSchedulingTerm =
@@ -475,13 +475,13 @@
 , RBDVolumeSource =
     ./schemas/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:ac07443af1c9f57e0175d9468507c2259feee9ea807f71ba4f5383658d62cd36
 , ReplicationController =
-    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:c9f9976495e975351e691417c4470ccbc3e6d9ea02ee727832ac90ec8439bfb8
+    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:edfd2aa5e8bc64f21e417877be5f72bcb185d5a04193b361ef352a0e5a8c95c6
 , ReplicationControllerCondition =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicationControllerList =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:bae303faa09a536af3320f4348226b6cafed54cdf271e7d0ff8c02adefd18be9
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:64428551ac646a5f29aeeb7ed6b25da7cc1bbb8f78b50fcd0c0c44257f05f2b3
 , ReplicationControllerSpec =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:63b096da6c57650ec1476f0b5f00febed4d69e107f851c1cbd71638330c81538
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:141695eef7324d06a0d009be0cbb4c2df5de1d406db9d6d6a5bdcd75ef643747
 , ReplicationControllerStatus =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , ResourceFieldSelector =

--- a/1.18/types.dhall
+++ b/1.18/types.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:209723e7a750dc2b67fb355e9847f70439fecc3d68e97ae2d20d9b0f33f1c643
 , DaemonSet =
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:d7c19aff4e38a8fa4f1f0a65710a21d49767f8349011039a0fcebf678201db55
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:adb0c0ac01b5f702a7a64be58d3369a006c982b372d93ab77cb5fa6a21e517cd
 , DaemonSetCondition =
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , DaemonSetList =
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:ed5c80b345c33a7824ad5a1971b1b2e49cd8e5875b43a1453ff9c55c246b34ba
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:a164b3879ead69b21724d73ca8ccc9416dfb26c41daffe1665cc247b133181d7
 , DaemonSetSpec =
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:55d2f0b4500a542979ea5a83a03c49aa75b1fae6fc859ed92ed6527b271cf882
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:06ccbc1bf866c977fe79ee16696996c260c3100a00839d947c8b0795b86022b7
 , DaemonSetStatus =
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 , DaemonSetUpdateStrategy =
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 , Deployment =
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:9f0397d5a91b73f2357d5071e3d087c800bd21e7326cec567a9ab740c52658ca
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:d0dda015757e008b5cb163fcb0cf0385bd08cb4b806953cc759de48ed61bd3c8
 , DeploymentCondition =
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 , DeploymentList =
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:6cb1a13e03ff51b56843b3a4788966458be21aa075105a07016f6ab9ad601716
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:91a0fe2db6522f8a2a8d887321cbbe35a6eb628ddb159f60f2bb7a7933b02d93
 , DeploymentSpec =
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:5603c7f677c5cd60ca6388c2a176113c440c6a637d06b37055f2f03124b4d761
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:20f6acc0ab2896df5f4eb3ced51a2a51f5f926b1b86e446c461611fed3884801
 , DeploymentStatus =
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 , DeploymentStrategy =
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 , ReplicaSet =
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:95cc605bcd0a3badaaa747c4a8f6c3778b74ee3c8d01589412aff844bbb60a0b
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:2b50271ab0ee712f8379a4d8c214c4093ccbc439bde1123c29bb2509af093c94
 , ReplicaSetCondition =
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicaSetList =
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:0ea519f2226b76b269aa693d62c2b48afb73e3be81fcd226617be6a662777811
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:a46e1dd2e77c3bbbb2173e13458eab91413087073832e8c52694fccd12345711
 , ReplicaSetSpec =
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:2551e1c803fe00622acb49c586ae7b379aa7d55c54f5fbe409aa75e702f74bab
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:171993a8b4cfcaafdeb7e9e3cf41770169e32cb3f0d5ff106fdd99fa7e07fb03
 , ReplicaSetStatus =
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 , StatefulSet =
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:1c882a7a2d5cb443bdcd2b30780723ab9de08f0aa62e244797a1da7b408e4270
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:47f26cc3c0e9a23c68f6a1f970185a95afe921ebc5aec498c7d13cb0f3776a9a
 , StatefulSetCondition =
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , StatefulSetList =
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:109d1120983e226ba37afbfc62945e33dd9c61b2bd5a22a2f06967a1deea1d21
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:a6245a65fdedc4b477203d67e45f6d90894ef4e99fc97c8f714d9864f92a8b20
 , StatefulSetSpec =
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:501f01e3cce1f36350606397c92e6b4e4b1725b8d59408d5713e561abdae1810
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:24d435f60406eff05c3e0b0354dcc098e3bf614281b829874b83c93f8048f618
 , StatefulSetStatus =
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 , StatefulSetUpdateStrategy =
@@ -173,25 +173,25 @@
 , ResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , Job =
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:b841e652ba955463cd340a4768b52d7b1aa7a8448e34037b106a5a4ae4fcc2d2
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:d2ca01d1076718ccfbbba6b05c22bedac1905bc34ce56d76b915329560af51b0
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:dac20de44ae7456dbd4c6b5c78ab83f39c4a7a6df7cad9309e927929dfb0e04c
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:cd44c38ab6c31bf0a4fda663e2166572727939bd14f1a60865ac5c39dcbef1c5
 , JobSpec =
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:b9b90ea60d0ed5738223d0e0de4fbc4f4e7ede339919b3f706164d1e70df71cf
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:5c2abe37696d3e0d6feb7f6d64304465ee345a8990b0b6d96cc0ca28796cd903
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 , CronJob =
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:248b490e47913df81d327cff5bc9627e4239b1644ad9acc860fef7490187195f
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:3ede63876c456cad744604119e0227dd06ae36e0df153aef22ca02194e89a182
 , CronJobList =
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:1bd58d542f8e07b33b1033f310ae75b00ddb8eaf06b716cfc0393b9f42f74a34
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2bc0dde1f69dca5e14f0c6d8ba7411d6b8a9b15b59dc94c15cef7bf58b5e6a64
 , CronJobSpec =
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:d219ce4ae538d99c9e7adcd4e21914d593ae7650e6be68a5e67b758957442536
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:b9429ee936bd0579bb4f7da0425badf9e5d4d74315da05d233fe78a46aba3c5d
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 , JobTemplateSpec =
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:e4bf384f9bd34928413478083fb0cb563fa1c65e770f87ec50a076637ecb0410
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:e78734f2857f0a483791f6cd2df68dd85bf52d0717e13b1548fccd6d9f26fb00
 , CertificateSigningRequest =
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:c9e0c5f8c168463968734902585f37ff46a4d8f53ddb8815920a563d05f64727
 , CertificateSigningRequestCondition =
@@ -455,11 +455,11 @@
 , PodStatus =
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:76800003e551406fea214c10166149b231668764a166a11579a1dcb8eac94d81
 , PodTemplate =
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:148fac9cd463278a5368e4062ecdc29841e540999a84be99f74c57b3206cac20
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:42b8f01808b595bacc01fbbae6dc82d21c9a8e5be8cfe1e8ee9f04486ccc34be
 , PodTemplateList =
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:8856ff852631f6286e6308ded0a68d57ccfc998ab78370a014091be570817bc9
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:8a3a471dccd869cb9fce68939a49eff36d32f4a667d4412c3c46fa613d39e924
 , PodTemplateSpec =
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:5fffd90a8d4fca1ad8e718b85063cbdb9cc49205ca1f8761423792b4f7eedb3a
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:80fd6457f5a192a07ba74b26974382e0e2718261aa4578a2f284c98f1cba9393
 , PortworxVolumeSource =
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 , PreferredSchedulingTerm =
@@ -475,13 +475,13 @@
 , RBDVolumeSource =
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 , ReplicationController =
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:93a69e39dfe3333aa0b8bf4211d3fa03efcbdba85ab5e5cc6be47429e936c35a
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:39faa4913a7478ef70924ef6b8e848d6953b28eceb7c70b016400f930b8a557a
 , ReplicationControllerCondition =
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicationControllerList =
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:1341ebb5fbbff70a6355855eafbfa12c680be8579fb7ac26ee79b5816aea5ef2
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:a1f03771660078379813a83e481ff3688b32aee332444b58a0568a5599b2b67b
 , ReplicationControllerSpec =
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:9d3f0c1848d528e0be49104ee219027aa063de6e77046cda2fe9f78c8b6aa13d
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:25d8a4f7b13d5320511e27c04a186f886d2e308fe157a008d5bd1a9e5e564ce5
 , ReplicationControllerStatus =
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , ResourceFieldSelector =

--- a/1.18/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.18/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.18/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.18/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.18/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.18/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.core.v1.PodSpec.dhall
 }

--- a/1.18/typesUnion.dhall
+++ b/1.18/typesUnion.dhall
@@ -17,37 +17,37 @@
 | ControllerRevisionList :
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:209723e7a750dc2b67fb355e9847f70439fecc3d68e97ae2d20d9b0f33f1c643
 | DaemonSet :
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:d7c19aff4e38a8fa4f1f0a65710a21d49767f8349011039a0fcebf678201db55
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:adb0c0ac01b5f702a7a64be58d3369a006c982b372d93ab77cb5fa6a21e517cd
 | DaemonSetCondition :
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | DaemonSetList :
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:ed5c80b345c33a7824ad5a1971b1b2e49cd8e5875b43a1453ff9c55c246b34ba
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:a164b3879ead69b21724d73ca8ccc9416dfb26c41daffe1665cc247b133181d7
 | DaemonSetSpec :
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:55d2f0b4500a542979ea5a83a03c49aa75b1fae6fc859ed92ed6527b271cf882
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:06ccbc1bf866c977fe79ee16696996c260c3100a00839d947c8b0795b86022b7
 | DaemonSetStatus :
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 | DaemonSetUpdateStrategy :
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 | Deployment :
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:9f0397d5a91b73f2357d5071e3d087c800bd21e7326cec567a9ab740c52658ca
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:d0dda015757e008b5cb163fcb0cf0385bd08cb4b806953cc759de48ed61bd3c8
 | DeploymentCondition :
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 | DeploymentList :
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:6cb1a13e03ff51b56843b3a4788966458be21aa075105a07016f6ab9ad601716
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:91a0fe2db6522f8a2a8d887321cbbe35a6eb628ddb159f60f2bb7a7933b02d93
 | DeploymentSpec :
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:5603c7f677c5cd60ca6388c2a176113c440c6a637d06b37055f2f03124b4d761
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:20f6acc0ab2896df5f4eb3ced51a2a51f5f926b1b86e446c461611fed3884801
 | DeploymentStatus :
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 | DeploymentStrategy :
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 | ReplicaSet :
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:95cc605bcd0a3badaaa747c4a8f6c3778b74ee3c8d01589412aff844bbb60a0b
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:2b50271ab0ee712f8379a4d8c214c4093ccbc439bde1123c29bb2509af093c94
 | ReplicaSetCondition :
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicaSetList :
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:0ea519f2226b76b269aa693d62c2b48afb73e3be81fcd226617be6a662777811
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:a46e1dd2e77c3bbbb2173e13458eab91413087073832e8c52694fccd12345711
 | ReplicaSetSpec :
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:2551e1c803fe00622acb49c586ae7b379aa7d55c54f5fbe409aa75e702f74bab
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:171993a8b4cfcaafdeb7e9e3cf41770169e32cb3f0d5ff106fdd99fa7e07fb03
 | ReplicaSetStatus :
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | RollingUpdateDaemonSet :
@@ -57,13 +57,13 @@
 | RollingUpdateStatefulSetStrategy :
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 | StatefulSet :
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:1c882a7a2d5cb443bdcd2b30780723ab9de08f0aa62e244797a1da7b408e4270
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:47f26cc3c0e9a23c68f6a1f970185a95afe921ebc5aec498c7d13cb0f3776a9a
 | StatefulSetCondition :
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | StatefulSetList :
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:109d1120983e226ba37afbfc62945e33dd9c61b2bd5a22a2f06967a1deea1d21
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:a6245a65fdedc4b477203d67e45f6d90894ef4e99fc97c8f714d9864f92a8b20
 | StatefulSetSpec :
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:501f01e3cce1f36350606397c92e6b4e4b1725b8d59408d5713e561abdae1810
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:24d435f60406eff05c3e0b0354dcc098e3bf614281b829874b83c93f8048f618
 | StatefulSetStatus :
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 | StatefulSetUpdateStrategy :
@@ -173,25 +173,25 @@
 | ResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | Job :
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:b841e652ba955463cd340a4768b52d7b1aa7a8448e34037b106a5a4ae4fcc2d2
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:d2ca01d1076718ccfbbba6b05c22bedac1905bc34ce56d76b915329560af51b0
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:dac20de44ae7456dbd4c6b5c78ab83f39c4a7a6df7cad9309e927929dfb0e04c
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:cd44c38ab6c31bf0a4fda663e2166572727939bd14f1a60865ac5c39dcbef1c5
 | JobSpec :
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:b9b90ea60d0ed5738223d0e0de4fbc4f4e7ede339919b3f706164d1e70df71cf
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:5c2abe37696d3e0d6feb7f6d64304465ee345a8990b0b6d96cc0ca28796cd903
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 | CronJob :
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:248b490e47913df81d327cff5bc9627e4239b1644ad9acc860fef7490187195f
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:3ede63876c456cad744604119e0227dd06ae36e0df153aef22ca02194e89a182
 | CronJobList :
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:1bd58d542f8e07b33b1033f310ae75b00ddb8eaf06b716cfc0393b9f42f74a34
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:2bc0dde1f69dca5e14f0c6d8ba7411d6b8a9b15b59dc94c15cef7bf58b5e6a64
 | CronJobSpec :
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:d219ce4ae538d99c9e7adcd4e21914d593ae7650e6be68a5e67b758957442536
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:b9429ee936bd0579bb4f7da0425badf9e5d4d74315da05d233fe78a46aba3c5d
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 | JobTemplateSpec :
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:e4bf384f9bd34928413478083fb0cb563fa1c65e770f87ec50a076637ecb0410
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:e78734f2857f0a483791f6cd2df68dd85bf52d0717e13b1548fccd6d9f26fb00
 | CertificateSigningRequest :
     ./types/io.k8s.api.certificates.v1beta1.CertificateSigningRequest.dhall sha256:c9e0c5f8c168463968734902585f37ff46a4d8f53ddb8815920a563d05f64727
 | CertificateSigningRequestCondition :
@@ -455,11 +455,11 @@
 | PodStatus :
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:76800003e551406fea214c10166149b231668764a166a11579a1dcb8eac94d81
 | PodTemplate :
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:148fac9cd463278a5368e4062ecdc29841e540999a84be99f74c57b3206cac20
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:42b8f01808b595bacc01fbbae6dc82d21c9a8e5be8cfe1e8ee9f04486ccc34be
 | PodTemplateList :
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:8856ff852631f6286e6308ded0a68d57ccfc998ab78370a014091be570817bc9
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:8a3a471dccd869cb9fce68939a49eff36d32f4a667d4412c3c46fa613d39e924
 | PodTemplateSpec :
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:5fffd90a8d4fca1ad8e718b85063cbdb9cc49205ca1f8761423792b4f7eedb3a
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:80fd6457f5a192a07ba74b26974382e0e2718261aa4578a2f284c98f1cba9393
 | PortworxVolumeSource :
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 | PreferredSchedulingTerm :
@@ -475,13 +475,13 @@
 | RBDVolumeSource :
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 | ReplicationController :
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:93a69e39dfe3333aa0b8bf4211d3fa03efcbdba85ab5e5cc6be47429e936c35a
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:39faa4913a7478ef70924ef6b8e848d6953b28eceb7c70b016400f930b8a557a
 | ReplicationControllerCondition :
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicationControllerList :
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:1341ebb5fbbff70a6355855eafbfa12c680be8579fb7ac26ee79b5816aea5ef2
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:a1f03771660078379813a83e481ff3688b32aee332444b58a0568a5599b2b67b
 | ReplicationControllerSpec :
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:9d3f0c1848d528e0be49104ee219027aa063de6e77046cda2fe9f78c8b6aa13d
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:25d8a4f7b13d5320511e27c04a186f886d2e308fe157a008d5bd1a9e5e564ce5
 | ReplicationControllerStatus :
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | ResourceFieldSelector :

--- a/1.19/defaults.dhall
+++ b/1.19/defaults.dhall
@@ -17,7 +17,7 @@
 , ControllerRevisionList =
     ./defaults/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:2343b690c1c4d49b5e1fe09da5a71fc9e8c74f2a9975764b0ad41cf597b6b616
 , DaemonSet =
-    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:88cc82cce52fb60df6c1033be15f10b56544223531bc3253dd14c4bd25286853
+    ./defaults/io.k8s.api.apps.v1.DaemonSet.dhall sha256:8f371e68f438f5c0a6e661cffa418d29b1cbb6cbe60f6be1d02909c9839e8713
 , DaemonSetCondition =
     ./defaults/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , DaemonSetList =
@@ -29,7 +29,7 @@
 , DaemonSetUpdateStrategy =
     ./defaults/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:0267659f9e8647bbf2e9f9073536c4c0c60b8ff1c076523cd7773b05e8d1c270
 , Deployment =
-    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:032321734a85f6fa3e2d354991790b6ab5bada7808e4cff1a2acc9ef1597afdd
+    ./defaults/io.k8s.api.apps.v1.Deployment.dhall sha256:bd29f51a94e3eadec723bc21dc28cda545c67f253149b27b86864e82f023837f
 , DeploymentCondition =
     ./defaults/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:006ebe956ae6e2918eb18beed3f6378d0f79437bfc449f4b6c7852206a7c7e5d
 , DeploymentList =
@@ -41,13 +41,13 @@
 , DeploymentStrategy =
     ./defaults/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:e5ba779274cb5a0b72069647e1aa8b257380ddb3b183aef45233028c399f65b9
 , ReplicaSet =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:be89c576608d401dafe9bf3ed59efbed39b76b200efc8dbe5587bc94903107bd
+    ./defaults/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:ea283753bddb222f2e076b765fbe26d39320b2f6afd8946586394431ba8bacbf
 , ReplicaSetCondition =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicaSetList =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:e57739bf261dfcdaec492632f1986b57c7d7bc45a4ba7be145beb64b739fe70f
 , ReplicaSetSpec =
-    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:53cf0d98bfc777cddc93ad4d3baad70c466674a4f5b4f1ec8cccd3e5f2ced8ea
+    ./defaults/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:a0b85c7a324f386e800be1e1e5a5bf63ac92f2d4c7646c90053cde0e62dc36ba
 , ReplicaSetStatus =
     ./defaults/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , RollingUpdateDaemonSet =
@@ -57,7 +57,7 @@
 , RollingUpdateStatefulSetStrategy =
     ./defaults/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:4d9feb8034f9f58692aebeed06474c07c387e5b8bc11c40dc36ec6390a26fa63
 , StatefulSet =
-    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:0a0785d814dae98fd57d00716bab61fa41c505dca4dcfb46ea6331c1d45c895a
+    ./defaults/io.k8s.api.apps.v1.StatefulSet.dhall sha256:caa87df8ce97cfb2696d9b8723b0f89c3f609a64e983f7d9cd490f4bbd4e841e
 , StatefulSetCondition =
     ./defaults/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , StatefulSetList =
@@ -161,7 +161,7 @@
 , ResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Job =
-    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:abbd8dc987630344142e7aaf8baa45e53324891a2da2ae536f701fe4b687be85
+    ./defaults/io.k8s.api.batch.v1.Job.dhall sha256:dd2837721203c2ff8cd516f4026edae03e3c6233d9054ec1a7ab305c69b27f24
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
 , JobList =
@@ -171,7 +171,7 @@
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall sha256:acf4f792ff1e56e53cb6d00ddc60f6ade85c44289efcbbfd2e5b81e1ac0347fc
 , CronJob =
-    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:f8733465d0df05f63cd343e9da9e041799f687ed66fd7a2508fe328665e2daa5
+    ./defaults/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:df230ebcd607e351cf3599081a7da9a99ad91b8d6877622f3d0fba5dc38ca899
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:d6f792b6d1f5cc8e862708490973d8b46eeb2d7adf4f3be3170a93ce2b70be7a
 , CronJobSpec =
@@ -179,7 +179,7 @@
 , CronJobStatus =
     ./defaults/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:751a6c74f8753d8467f43f76bc3b0661655a65daf9f907f6f814f01ade0fcd70
 , JobTemplateSpec =
-    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:dfb5b34c0035957e9051e46011f57c06ca504641ace541c6221fbfd809416726
+    ./defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:82017466882dbb47ea0452a96726385ef2081f4560659f2206fad9c22d310741
 , CertificateSigningRequest =
     ./defaults/io.k8s.api.certificates.v1.CertificateSigningRequest.dhall sha256:26eb1c67f6b262834b718668ad2c9ae7df252c78e2b282c03038b56c17ab135d
 , CertificateSigningRequestCondition =
@@ -441,11 +441,11 @@
 , PodStatus =
     ./defaults/io.k8s.api.core.v1.PodStatus.dhall sha256:1e5a1592d9c192d7d2021e9fde347019503a365372fe7c9b0af203477399a7ef
 , PodTemplate =
-    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:df3be3e487be850b83bf52d812a2f1020ad7728929452ea9b38f2e82b894bbf8
+    ./defaults/io.k8s.api.core.v1.PodTemplate.dhall sha256:57716905b105abd1e57393620555413deedd4ec9769e909fc1fd2486b148ce45
 , PodTemplateList =
     ./defaults/io.k8s.api.core.v1.PodTemplateList.dhall sha256:51ca93c255c7ab48ec42245f8b34a4effdd072cd019931f37ef304d8b46d6e6f
 , PodTemplateSpec =
-    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:fc321cf5d00144a1f8d6546c0ec0c32801786550589862cc0638b6111976e9ed
+    ./defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:a9399d89c13db8bb24d41078deee63d73d6e6d3f80a62aa0337d9d2761c3ea2a
 , PortworxVolumeSource =
     ./defaults/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:5d8e73366d928941a81088f57aaf538a8c3a8d171086228dcefe3aa8084e6a0a
 , PreferredSchedulingTerm =
@@ -461,13 +461,13 @@
 , RBDVolumeSource =
     ./defaults/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:0c1b0c6ed400fe9c63c9a97d77d6d6a69463137e0e43687c4087b7e8cce747c3
 , ReplicationController =
-    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:504eeae8dd20940a4c7cf1f795d9f118636f82156864f3cb1b793b0b191e41ab
+    ./defaults/io.k8s.api.core.v1.ReplicationController.dhall sha256:d8ce160dc5877eec2aaa015b22264b7bf2edbbf7279c250e500337f349d121e9
 , ReplicationControllerCondition =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , ReplicationControllerList =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:e7dcae86af1b284f62a6f26fe1e432a6a27a9fa5c3100acdad84794ac21ed769
 , ReplicationControllerSpec =
-    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:5c0acd8fcb7e3b63a8fc920d6f11349c2f4a3f8a29a05272721f6e523eceb56d
+    ./defaults/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:32db17b2b02f6130c02b2f90ea7206e4e0aaa55fc21d2d9e50fdaa0c781c1c0f
 , ReplicationControllerStatus =
     ./defaults/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c92e3262f4bec0334f8a9abeccf3c6bab9f98c3a5a09cfb6b95c48a45a2c895d
 , ResourceFieldSelector =

--- a/1.19/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.19/defaults/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.19/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.19/defaults/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.batch.v1.JobSpec.dhall
+}

--- a/1.19/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.19/defaults/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,1 +1,4 @@
-{ spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall }
+{ metadata =
+    None ./../types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+, spec = None ./../types/io.k8s.api.core.v1.PodSpec.dhall
+}

--- a/1.19/package.dhall
+++ b/1.19/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:531ec683eef9438671e26722c944fe891a94b79e93ff2ab1ebea7ee22b63bdec
+  ./schemas.dhall sha256:63830056de753ad9d5bbc1dcb36e105ac53ebdd7f108f2760e7092eaf81faab5
 ∧ { IntOrString =
-      ( ./types.dhall sha256:565f1c5821c7996fc287927923be53f36fcbf47b8971eef85a96616bbda5b838
+      ( ./types.dhall sha256:1c7e1086cb07cbb0337ef08429991db347cca9379599d7ad82a300847a76f02f
       ).IntOrString
   , Resource =
-      ./typesUnion.dhall sha256:74d6a291b86429bd314b25d2796904b484b7b5155304c5703f95811a69389dfe
+      ./typesUnion.dhall sha256:35c31aa937f8e4bd62cdb51cde621195c291229c1e953ac6bf66f6ed26213162
   }

--- a/1.19/schemas.dhall
+++ b/1.19/schemas.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./schemas/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:139727b422a6c643c13a021400e75ed9df5bd955c86439c018a1bbb5ac51f802
 , DaemonSet =
-    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:8231308f41d465d69076b9ead8b0fed87026aebc20da057b5622f57c59cf6a35
+    ./schemas/io.k8s.api.apps.v1.DaemonSet.dhall sha256:00d4df1194f04b6d279b6fd3f0fb2f116e40aaf9e6f4a5de848d127053a39c7c
 , DaemonSetCondition =
     ./schemas/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , DaemonSetList =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:060084462f696dafe03c05bbd3421598338bfb435dfccc1d4f7153fb6e6c95bd
+    ./schemas/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:3b305225c29959e7d1c424c133b78f64fec9978fd00abc5f5d5190e8a1339bb0
 , DaemonSetSpec =
-    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:5474bc08022ed2f461113843accf4aa5ae57da3016a2e34a4a8b375d15dba986
+    ./schemas/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:de8272ec2c29a2e30b7676631011ffe54fb29e4fedb25ef639ffb522a414868e
 , DaemonSetStatus =
     ./schemas/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:a68e46f267e6a5071080338953f8b1d13dff20cbfc06ae4b25f7645ff0b6cff6
 , DaemonSetUpdateStrategy =
     ./schemas/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:3efad19fff60b45006bb76c1bb6bd872e33a62d006dc6c6cd699c5945342814a
 , Deployment =
-    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:777151c49640a0c75bb0d11e7cd0d4a2f8401f6ddf2c34e209184c60a2c4eff5
+    ./schemas/io.k8s.api.apps.v1.Deployment.dhall sha256:18bbe7e364a53fa3821c6fdfa71b121b6248f6b16d56b1d76cb372b1be1417d2
 , DeploymentCondition =
     ./schemas/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:f6d653c489ad36f5ef1c422a5a8297e7e73b95210cc0e4224611c6188bad3fd5
 , DeploymentList =
-    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:957e045fe2c75d9fb16256a797ed0a9cd502e62d3f04149d4c077812e6ee22e2
+    ./schemas/io.k8s.api.apps.v1.DeploymentList.dhall sha256:3b916d5ae02dedbaa9287890f2d0a8864fc98655d3baf91fc9cd6fab28372d92
 , DeploymentSpec =
-    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:c74b8a3f82afcaa0e173a2f6a0d2868eff82398a0e8af998a477e1b98763f37e
+    ./schemas/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:f1c91812aea850add9dc9a60d2b600868cbd5ccf625194f099c3bd184827c455
 , DeploymentStatus =
     ./schemas/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:6c1a6f0ab5f98b0ae2aa9d861ea0ede60adbf94b1e21f0e2be39d6abe21bda39
 , DeploymentStrategy =
     ./schemas/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:f6893d857d85ff5bf089070c9a3416026483331e40c3999c52dc17d9a06bdecd
 , ReplicaSet =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:c1851719a4f31ed011361a4c1d8e1d04eae25417e83dddf50c40077eebac21ad
+    ./schemas/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:4c3ba5f6f6f48507c7cd11170aaea6c02b7f10433f296377e99928477e0f0c3f
 , ReplicaSetCondition =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicaSetList =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:9bd932ea1c660c7a6cc421c1341208a375be7fb9e3a890d8dfcd3197fd7c4c8c
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:edd734d52f65ded65832df21ef14a1394bf5e4708731cf60e52fdcb047306017
 , ReplicaSetSpec =
-    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:8245f07029b549c9660496f1e53145f7aad9ffcb8e23ec9f0e3f21c311facc78
+    ./schemas/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:05efc679dba30f7418d12f66be0f55d365e14fced6fc94d5dc9798fa9022d67a
 , ReplicaSetStatus =
     ./schemas/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./schemas/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:0471cec7aab65313bb60ff3f774ee8d8c8e406f16b34f3dd27b50659055acecb
 , StatefulSet =
-    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:15b9d7a2b4a99b36118bb20d4bbef51665719ffe884ab4d0df3a914105c8ae3f
+    ./schemas/io.k8s.api.apps.v1.StatefulSet.dhall sha256:92b66b99c2536b2f67e2ef8736a5e1e177d58759b0e393ccf575e9c52e3b3713
 , StatefulSetCondition =
     ./schemas/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , StatefulSetList =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:35871c10189f69d8c3af217708e5e9cd8416b4d2595713d8fd1738cfb5ffbdf7
+    ./schemas/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:4c6ec24e5e8ffb8d8c45c11801f5af08cb81b566d7e5063b5ac51027c07ea207
 , StatefulSetSpec =
-    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:c3da0aa1be727f5b39ebb28d0cf80d6902ffaec92a905d95c4883b5e31375750
+    ./schemas/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:a3fb8cce81724c5b912fc158a5d32c21e6ffd5788d930c330ab5376d8bca999f
 , StatefulSetStatus =
     ./schemas/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:a490d193b72e53cbb9b1fe35dde9bc02415e3f01bf8ce8a516ddbad25855df42
 , StatefulSetUpdateStrategy =
@@ -161,25 +161,25 @@
 , ResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , Job =
-    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:91b7f59857ebbc145b1892b429c829ab1eed977de715dbd6cc63ca4dd42999c3
+    ./schemas/io.k8s.api.batch.v1.Job.dhall sha256:70410265544f6041c5d437f6e97301bc44b87aa69734beae44704fc230b4295e
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
-    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:a37325c47ba8e44c24812135f42b86dd81c17538c60dc60a28e3f5481ba09c7b
+    ./schemas/io.k8s.api.batch.v1.JobList.dhall sha256:3b69861e8604e3e9151d8af7d4b64fe2f357c3b4972a9a0d1c9165d021335fb4
 , JobSpec =
-    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:fecdf2adeed38f62fd7231a6bfc1feddefb5082dfa91e29a9fc43c54bc2d1208
+    ./schemas/io.k8s.api.batch.v1.JobSpec.dhall sha256:e08e23b31beb1ad88cef2eb7aaf5808c7d4627540b4f27a6b5c08862a2f1b7d0
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall sha256:ddbf73e9d4be060bdfb9aabc84c1ad30860a6ac6b37fcdbff7bbae8e473a33c1
 , CronJob =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:b24d6662da11b1f8ed381862db34f215c4f4bdc0cdb7d1c6474b0133791f7bbe
+    ./schemas/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:02c170fa801d0486a5ebaf97965768a3102eaf4090278defeb9e2f6580c79a87
 , CronJobList =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:e573bcedcd505b5d45a3aded69fbbcd88da127efa4aaa29acc0f25e628932d97
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:f8e148519be48309210fded5c85c6c44c010b1ef1c1893fdfc4756f58e0723f0
 , CronJobSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:6ac1f2b422465f719ddf12a76f53d357b363a4c273960d095024e5a98e6da743
+    ./schemas/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:96fd2a2c3a8b47346429de31c1aee1fcd2245601b56492620cdf8ba1573c1235
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:aaef515cade329c5c1bccb54d90e32c20c3b7bcb96ffdee38650292cf56c10d4
 , JobTemplateSpec =
-    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:5b9e904d9ee541af03d942557ba2d7ad8a42f0ceb1bd3dc8a57485498b5e3881
+    ./schemas/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:d38af21ecf561720cd4bd96d8bf00d1000b480f669a0cf4c91cefacfc5964e43
 , CertificateSigningRequest =
     ./schemas/io.k8s.api.certificates.v1.CertificateSigningRequest.dhall sha256:bdfc824cfb28b7d2fdd6104cb0da40d9fab9dd70f7f86384cf732542d476a741
 , CertificateSigningRequestCondition =
@@ -441,11 +441,11 @@
 , PodStatus =
     ./schemas/io.k8s.api.core.v1.PodStatus.dhall sha256:bca3d68a0c9b023f53c79aa7cea5e3d5181fd460adf03d0732f60edf82e845fe
 , PodTemplate =
-    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:f11058081f51414c8e24cafda3f0fbb935923c8e57e3ce2b780b1567b5d46b1a
+    ./schemas/io.k8s.api.core.v1.PodTemplate.dhall sha256:4f7f0b2bdf3ca1cd5b17cc659fdcf34bcd1df6a9c35b350cdbd80b33ea879547
 , PodTemplateList =
-    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:fb55f28b4b06cb0774002c733be31cdf720bf23ec7d20bb2884612e527196c34
+    ./schemas/io.k8s.api.core.v1.PodTemplateList.dhall sha256:936b9109012fdcdc6fdf90e963f092fd4017a17864fdef6e62c9841b9961ce8a
 , PodTemplateSpec =
-    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:d68cf65b9c9dffc2e22da7803398f16bfd6943b4685e75037bd461d3d9f734db
+    ./schemas/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:1edeeff224e2312d2ebac238bd0dbaed587fb131524d225c0b72ce3bacb78fa2
 , PortworxVolumeSource =
     ./schemas/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:b0bf02de5706c9f17b2dfb7f5938941151708cffc2bf1e4c69ca4a9ed1e4b735
 , PreferredSchedulingTerm =
@@ -461,13 +461,13 @@
 , RBDVolumeSource =
     ./schemas/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:ac07443af1c9f57e0175d9468507c2259feee9ea807f71ba4f5383658d62cd36
 , ReplicationController =
-    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:70b67ea425c0b8c04396b5aafd36730e6c0378b7703dc9f25262426a87adb2d4
+    ./schemas/io.k8s.api.core.v1.ReplicationController.dhall sha256:a4a1dd030e14977afccd51b6b1ba49df6e051607680a158f508134a94a2af032
 , ReplicationControllerCondition =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , ReplicationControllerList =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:2613b5d6b908aaec04a55e1c47557d241ce1e6de00e24c8c51ed2b37fbb8aacd
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:4f6770f69d5d591d98f2123543481d4af9d559455286d58c4d928794279c5f87
 , ReplicationControllerSpec =
-    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:229d0ccdfebf32530cccb347c057b8fb5591fdb6535015fcf22189f2aeafbca0
+    ./schemas/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:40f446a462bb62abe2502b95386b857e41a25c9a742051d1575928055941df76
 , ReplicationControllerStatus =
     ./schemas/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:c11f64d49e217518194fd9ebed8199868e05ef29d7118a78a01a68bf5bd74d02
 , ResourceFieldSelector =

--- a/1.19/types.dhall
+++ b/1.19/types.dhall
@@ -17,37 +17,37 @@
 , ControllerRevisionList =
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:209723e7a750dc2b67fb355e9847f70439fecc3d68e97ae2d20d9b0f33f1c643
 , DaemonSet =
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:e5404e8f29c22cd08688af5e61952cf138876245d216669a32e12d4ddc5e0518
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:811983a3c201348e673140636b0dabfd24e74f57ad4d7e647149c7c86c86c493
 , DaemonSetCondition =
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , DaemonSetList =
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:9ae7c5fa814f68b92abecf2c1499ceba57a5cd21ab446da500504f25143d9c46
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:c4dc1927b150b150659dc89b80cc2640bf78d72fc738b73b9a1a621670883619
 , DaemonSetSpec =
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:e546faac8ad83a9b1e6180a09bc174182aee5e34b94d6bb25adb1ceaaa8fda28
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:d83653e51cd046279b9ba69b7b5fc799cebd864ae3f8c67c895f231a0ccf6c82
 , DaemonSetStatus =
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 , DaemonSetUpdateStrategy =
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 , Deployment =
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:a9d336ef771f39bc5a3f0ceeca3b80564aa345859cb3f3547fe29c44bb3d4323
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:febc887323b5949004bc3dfc979fcecaaa0d45861853987477b4c516b713d05d
 , DeploymentCondition =
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 , DeploymentList =
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:e6bc99f4549d5ab5c6765f1ed21277bc59a5a8327c3e8ca3d7f8ba50558d798e
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:80aae64c830fbc819a336d31697321f3d97818a8b80ebd5a983bde933bf964b4
 , DeploymentSpec =
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:e3d032f724494048060c4c46dfe70abf52f81dc8f22cd3308cf5064034d576af
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:315084d11333ade27a03b1204fecb0d1c713bfecc99a86c0e9b06a8b29d4aa95
 , DeploymentStatus =
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 , DeploymentStrategy =
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 , ReplicaSet =
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:337e084b7d0ebb7203af2911526b4088ed4db7640b4e435e88d081647f3046d1
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:6478f47365d9e8315aafcdc6856b9e53ce267cff6157e46f3cea90759eb36246
 , ReplicaSetCondition =
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicaSetList =
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:8ebf08364b6dbca0c9dd2860154716dac94949861174dd47a4f4e9463aaed994
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:611aae4f495a9e16b7f16c226d7261999273424d5d54d18f2292c07cfc660175
 , ReplicaSetSpec =
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:ccf9fb81985f619fae4c3aaf789a20bb754394f791f2e1bf29719b1dc1bdc092
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:a7cc31a111c6754447eea5b9a94e3fe1be93f64ddd27a2813f0b49686b4f0a8a
 , ReplicaSetStatus =
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , RollingUpdateDaemonSet =
@@ -57,13 +57,13 @@
 , RollingUpdateStatefulSetStrategy =
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 , StatefulSet =
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:d3ab5dc28cc1e507a04fdec6cb5314c3726c08f15d9469cf1cd9f81e0f4ce259
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:9f75f403ee21eaa7a94a6ecb8b48b2fa9b581abcdebf872bac48767ab2f0b9c3
 , StatefulSetCondition =
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , StatefulSetList =
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:07469f1322ddba112a37f8d15f3bdb6f70a2fade8f8621b1b95a7151c240b7ad
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:657757b8d64a966eb88558cc651fe5ae2b9ff9a28e4c4012efdea4fb783bf163
 , StatefulSetSpec =
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:722c776fd2979df970e5011be7985f17501e41baa76c65b5dfb63029eb715bee
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:3b1c223a20deaeb75065ae869071e8e32bb84923d05dbadcfd492635784d705c
 , StatefulSetStatus =
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 , StatefulSetUpdateStrategy =
@@ -161,25 +161,25 @@
 , ResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , Job =
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:40b32e724a4ac2e0bf07a5e790cd222957827b860ae5efca29ca34c279c048e1
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:e30079430ab58eb97b52901180669b85b4aa83b88255efe2b338c98be5bbee7d
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:be05b561f6034d26f02150a98b31e6cfa5c8aec9a6452be54f96fe5abf1eb3e1
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:75eb3463547014dc60541e8e31b0d934a76533b031dd28aacf31b533bfe62941
 , JobSpec =
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:c70139c9ab92c523894209fb62c37f46d8fa36c2fee7fc40e790c0da72452999
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:dd0af4a822fcc098d090e55f124e4e99c24012c825917eedc3f88744d20109fe
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 , CronJob =
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:31d13fc6e10bd6b29272029a9708bb0ab1b7980bc9e371fd82c21869aad0b754
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:db9c83649775ea2d7d34d3195955da521312fb0e987b37302dac68698f39722f
 , CronJobList =
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:8b2cd3d6127a0d770090d81807a21ee17769476818ff3ad25a13866384de3783
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:77c9a7dd89f52010c5737fde38fd94d4677fb4a1b7f8721a7a895bfef3ca434b
 , CronJobSpec =
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:4633c78e3d8df760908b2604e13bc81c918d8bb7a6c4fdbb913f4ac263e90efb
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:6d0f37be10ee023611af06026c6ddcf777ef93c13dd8856a2d1e22e8035aa8cd
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 , JobTemplateSpec =
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:fa51dc573a1854afb66cd97fcb69702d02d81a0433b84e39ea5c3c58ebbbad02
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:e23a621fd5b72ff23a3a142f653992c08c88b40de89549130ca6e42930617940
 , CertificateSigningRequest =
     ./types/io.k8s.api.certificates.v1.CertificateSigningRequest.dhall sha256:f509eeb17d50fef721a98b06f9c76dee538404a896555a7afcabfff6da28aa2a
 , CertificateSigningRequestCondition =
@@ -441,11 +441,11 @@
 , PodStatus =
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:76800003e551406fea214c10166149b231668764a166a11579a1dcb8eac94d81
 , PodTemplate =
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:20a37746c455f2cb1924b70e5ce290db9cdc801d20e333940e3dffa49b041da0
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:b7e5c968a91d88780dca74cab2d642b696d2ca5b9aa6abdfaf979e2ac429e46c
 , PodTemplateList =
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:d72738d9f928ffa5613b05b522890e671058420fd8bf98e9f78094d367b25fc9
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:3acc7b151d83b41ab39a387fbed8b41724e25e600999e43d204b8c444852c525
 , PodTemplateSpec =
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:9d70b35ad43d35ec0f04010ebc79b4300cb389fc1b0d1cb14be23ea2a823e998
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:4218e7959ec23a6199cee877d9b2647cffdc24b5474705fa32c6c2ca04e0613c
 , PortworxVolumeSource =
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 , PreferredSchedulingTerm =
@@ -461,13 +461,13 @@
 , RBDVolumeSource =
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 , ReplicationController =
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:288ef5a6b1e59b6f0b7c5f43ad196e9a6517c0e24d97129a2998f931e4f28c4a
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:d3592bffa4034cdf4d288338d98bdba7101dc95a68b4dbe61e229186139c0453
 , ReplicationControllerCondition =
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , ReplicationControllerList =
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:02e58458d994423a2a8d902c509bb47604227b7e76fcd0af92c901c9b0a5f768
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:3e25f40261d7a8748ad8057c76f66e2add9872f9ba94acf246f14836ecc56bef
 , ReplicationControllerSpec =
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:e6f7faf002a83e22f48f33f703984ee35df55c482ab9b817a59bbf753efcafdb
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:f9cbf62b5310dcda5adbaaba7b66a11767341ab630027e2c5ccc845e31425f36
 , ReplicationControllerStatus =
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 , ResourceFieldSelector =

--- a/1.19/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
+++ b/1.19/types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.19/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
+++ b/1.19/types/io.k8s.api.batch.v2alpha1.JobTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.batch.v1.JobSpec.dhall
 }

--- a/1.19/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
+++ b/1.19/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
@@ -1,3 +1,3 @@
-{ metadata : ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+{ metadata : Optional ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : Optional ./io.k8s.api.core.v1.PodSpec.dhall
 }

--- a/1.19/typesUnion.dhall
+++ b/1.19/typesUnion.dhall
@@ -17,37 +17,37 @@
 | ControllerRevisionList :
     ./types/io.k8s.api.apps.v1.ControllerRevisionList.dhall sha256:209723e7a750dc2b67fb355e9847f70439fecc3d68e97ae2d20d9b0f33f1c643
 | DaemonSet :
-    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:e5404e8f29c22cd08688af5e61952cf138876245d216669a32e12d4ddc5e0518
+    ./types/io.k8s.api.apps.v1.DaemonSet.dhall sha256:811983a3c201348e673140636b0dabfd24e74f57ad4d7e647149c7c86c86c493
 | DaemonSetCondition :
     ./types/io.k8s.api.apps.v1.DaemonSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | DaemonSetList :
-    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:9ae7c5fa814f68b92abecf2c1499ceba57a5cd21ab446da500504f25143d9c46
+    ./types/io.k8s.api.apps.v1.DaemonSetList.dhall sha256:c4dc1927b150b150659dc89b80cc2640bf78d72fc738b73b9a1a621670883619
 | DaemonSetSpec :
-    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:e546faac8ad83a9b1e6180a09bc174182aee5e34b94d6bb25adb1ceaaa8fda28
+    ./types/io.k8s.api.apps.v1.DaemonSetSpec.dhall sha256:d83653e51cd046279b9ba69b7b5fc799cebd864ae3f8c67c895f231a0ccf6c82
 | DaemonSetStatus :
     ./types/io.k8s.api.apps.v1.DaemonSetStatus.dhall sha256:8df7934b5710e2cd7436b009df0b714ede641037aaa5d5757e257f4f285515e8
 | DaemonSetUpdateStrategy :
     ./types/io.k8s.api.apps.v1.DaemonSetUpdateStrategy.dhall sha256:a395db54fa6333208b403ea5119ee6abf547f4bdc921c3e412e36ed47f619828
 | Deployment :
-    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:a9d336ef771f39bc5a3f0ceeca3b80564aa345859cb3f3547fe29c44bb3d4323
+    ./types/io.k8s.api.apps.v1.Deployment.dhall sha256:febc887323b5949004bc3dfc979fcecaaa0d45861853987477b4c516b713d05d
 | DeploymentCondition :
     ./types/io.k8s.api.apps.v1.DeploymentCondition.dhall sha256:7454a3ace769a8acf66bee0a25a9558dee6ff2dc7343d87e38524e7d3f1c8baa
 | DeploymentList :
-    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:e6bc99f4549d5ab5c6765f1ed21277bc59a5a8327c3e8ca3d7f8ba50558d798e
+    ./types/io.k8s.api.apps.v1.DeploymentList.dhall sha256:80aae64c830fbc819a336d31697321f3d97818a8b80ebd5a983bde933bf964b4
 | DeploymentSpec :
-    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:e3d032f724494048060c4c46dfe70abf52f81dc8f22cd3308cf5064034d576af
+    ./types/io.k8s.api.apps.v1.DeploymentSpec.dhall sha256:315084d11333ade27a03b1204fecb0d1c713bfecc99a86c0e9b06a8b29d4aa95
 | DeploymentStatus :
     ./types/io.k8s.api.apps.v1.DeploymentStatus.dhall sha256:9c3ae8b25a14bc2fdfe3bbfe292ee0c4b2ed3023dda4515d6c815e8ff41363ed
 | DeploymentStrategy :
     ./types/io.k8s.api.apps.v1.DeploymentStrategy.dhall sha256:b08c56c88f023d2b4e0ed8947c3396d33c29984fb31b4cf22ae56ed661cc031a
 | ReplicaSet :
-    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:337e084b7d0ebb7203af2911526b4088ed4db7640b4e435e88d081647f3046d1
+    ./types/io.k8s.api.apps.v1.ReplicaSet.dhall sha256:6478f47365d9e8315aafcdc6856b9e53ce267cff6157e46f3cea90759eb36246
 | ReplicaSetCondition :
     ./types/io.k8s.api.apps.v1.ReplicaSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicaSetList :
-    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:8ebf08364b6dbca0c9dd2860154716dac94949861174dd47a4f4e9463aaed994
+    ./types/io.k8s.api.apps.v1.ReplicaSetList.dhall sha256:611aae4f495a9e16b7f16c226d7261999273424d5d54d18f2292c07cfc660175
 | ReplicaSetSpec :
-    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:ccf9fb81985f619fae4c3aaf789a20bb754394f791f2e1bf29719b1dc1bdc092
+    ./types/io.k8s.api.apps.v1.ReplicaSetSpec.dhall sha256:a7cc31a111c6754447eea5b9a94e3fe1be93f64ddd27a2813f0b49686b4f0a8a
 | ReplicaSetStatus :
     ./types/io.k8s.api.apps.v1.ReplicaSetStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | RollingUpdateDaemonSet :
@@ -57,13 +57,13 @@
 | RollingUpdateStatefulSetStrategy :
     ./types/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy.dhall sha256:dad33ff65dde525b0796a1d7e81a345d4ae973743e3267be3a1bd0722cf5ab4b
 | StatefulSet :
-    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:d3ab5dc28cc1e507a04fdec6cb5314c3726c08f15d9469cf1cd9f81e0f4ce259
+    ./types/io.k8s.api.apps.v1.StatefulSet.dhall sha256:9f75f403ee21eaa7a94a6ecb8b48b2fa9b581abcdebf872bac48767ab2f0b9c3
 | StatefulSetCondition :
     ./types/io.k8s.api.apps.v1.StatefulSetCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | StatefulSetList :
-    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:07469f1322ddba112a37f8d15f3bdb6f70a2fade8f8621b1b95a7151c240b7ad
+    ./types/io.k8s.api.apps.v1.StatefulSetList.dhall sha256:657757b8d64a966eb88558cc651fe5ae2b9ff9a28e4c4012efdea4fb783bf163
 | StatefulSetSpec :
-    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:722c776fd2979df970e5011be7985f17501e41baa76c65b5dfb63029eb715bee
+    ./types/io.k8s.api.apps.v1.StatefulSetSpec.dhall sha256:3b1c223a20deaeb75065ae869071e8e32bb84923d05dbadcfd492635784d705c
 | StatefulSetStatus :
     ./types/io.k8s.api.apps.v1.StatefulSetStatus.dhall sha256:d5a3a33833911b1885d22dd9d5a8a90cb93d106d31b0690c81159288005a7c06
 | StatefulSetUpdateStrategy :
@@ -161,25 +161,25 @@
 | ResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | Job :
-    ./types/io.k8s.api.batch.v1.Job.dhall sha256:40b32e724a4ac2e0bf07a5e790cd222957827b860ae5efca29ca34c279c048e1
+    ./types/io.k8s.api.batch.v1.Job.dhall sha256:e30079430ab58eb97b52901180669b85b4aa83b88255efe2b338c98be5bbee7d
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
-    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:be05b561f6034d26f02150a98b31e6cfa5c8aec9a6452be54f96fe5abf1eb3e1
+    ./types/io.k8s.api.batch.v1.JobList.dhall sha256:75eb3463547014dc60541e8e31b0d934a76533b031dd28aacf31b533bfe62941
 | JobSpec :
-    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:c70139c9ab92c523894209fb62c37f46d8fa36c2fee7fc40e790c0da72452999
+    ./types/io.k8s.api.batch.v1.JobSpec.dhall sha256:dd0af4a822fcc098d090e55f124e4e99c24012c825917eedc3f88744d20109fe
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall sha256:359a0ae893c3951a17a95b44bd5c11707217055b227d331b71cd890db3ac201d
 | CronJob :
-    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:31d13fc6e10bd6b29272029a9708bb0ab1b7980bc9e371fd82c21869aad0b754
+    ./types/io.k8s.api.batch.v1beta1.CronJob.dhall sha256:db9c83649775ea2d7d34d3195955da521312fb0e987b37302dac68698f39722f
 | CronJobList :
-    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:8b2cd3d6127a0d770090d81807a21ee17769476818ff3ad25a13866384de3783
+    ./types/io.k8s.api.batch.v1beta1.CronJobList.dhall sha256:77c9a7dd89f52010c5737fde38fd94d4677fb4a1b7f8721a7a895bfef3ca434b
 | CronJobSpec :
-    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:4633c78e3d8df760908b2604e13bc81c918d8bb7a6c4fdbb913f4ac263e90efb
+    ./types/io.k8s.api.batch.v1beta1.CronJobSpec.dhall sha256:6d0f37be10ee023611af06026c6ddcf777ef93c13dd8856a2d1e22e8035aa8cd
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1beta1.CronJobStatus.dhall sha256:a72616aa1127fdd7dcc66b891dad1550f2830325b7c4d3b88ac1bbfde394a5ea
 | JobTemplateSpec :
-    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:fa51dc573a1854afb66cd97fcb69702d02d81a0433b84e39ea5c3c58ebbbad02
+    ./types/io.k8s.api.batch.v1beta1.JobTemplateSpec.dhall sha256:e23a621fd5b72ff23a3a142f653992c08c88b40de89549130ca6e42930617940
 | CertificateSigningRequest :
     ./types/io.k8s.api.certificates.v1.CertificateSigningRequest.dhall sha256:f509eeb17d50fef721a98b06f9c76dee538404a896555a7afcabfff6da28aa2a
 | CertificateSigningRequestCondition :
@@ -441,11 +441,11 @@
 | PodStatus :
     ./types/io.k8s.api.core.v1.PodStatus.dhall sha256:76800003e551406fea214c10166149b231668764a166a11579a1dcb8eac94d81
 | PodTemplate :
-    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:20a37746c455f2cb1924b70e5ce290db9cdc801d20e333940e3dffa49b041da0
+    ./types/io.k8s.api.core.v1.PodTemplate.dhall sha256:b7e5c968a91d88780dca74cab2d642b696d2ca5b9aa6abdfaf979e2ac429e46c
 | PodTemplateList :
-    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:d72738d9f928ffa5613b05b522890e671058420fd8bf98e9f78094d367b25fc9
+    ./types/io.k8s.api.core.v1.PodTemplateList.dhall sha256:3acc7b151d83b41ab39a387fbed8b41724e25e600999e43d204b8c444852c525
 | PodTemplateSpec :
-    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:9d70b35ad43d35ec0f04010ebc79b4300cb389fc1b0d1cb14be23ea2a823e998
+    ./types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:4218e7959ec23a6199cee877d9b2647cffdc24b5474705fa32c6c2ca04e0613c
 | PortworxVolumeSource :
     ./types/io.k8s.api.core.v1.PortworxVolumeSource.dhall sha256:6c20c2018deb04b8276fbbb6bde16225beca3e2d4d40120729a3c854ae9a8483
 | PreferredSchedulingTerm :
@@ -461,13 +461,13 @@
 | RBDVolumeSource :
     ./types/io.k8s.api.core.v1.RBDVolumeSource.dhall sha256:a3c3dbc95b50cb4e5438e48b4e583cf8cbec5f6b3daf694335f1b1b1b0f80972
 | ReplicationController :
-    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:288ef5a6b1e59b6f0b7c5f43ad196e9a6517c0e24d97129a2998f931e4f28c4a
+    ./types/io.k8s.api.core.v1.ReplicationController.dhall sha256:d3592bffa4034cdf4d288338d98bdba7101dc95a68b4dbe61e229186139c0453
 | ReplicationControllerCondition :
     ./types/io.k8s.api.core.v1.ReplicationControllerCondition.dhall sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | ReplicationControllerList :
-    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:02e58458d994423a2a8d902c509bb47604227b7e76fcd0af92c901c9b0a5f768
+    ./types/io.k8s.api.core.v1.ReplicationControllerList.dhall sha256:3e25f40261d7a8748ad8057c76f66e2add9872f9ba94acf246f14836ecc56bef
 | ReplicationControllerSpec :
-    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:e6f7faf002a83e22f48f33f703984ee35df55c482ab9b817a59bbf753efcafdb
+    ./types/io.k8s.api.core.v1.ReplicationControllerSpec.dhall sha256:f9cbf62b5310dcda5adbaaba7b66a11767341ab630027e2c5ccc845e31425f36
 | ReplicationControllerStatus :
     ./types/io.k8s.api.core.v1.ReplicationControllerStatus.dhall sha256:079fb913272c088967f80c8404e28b1b15756edf6ad3de056947f268ff4303da
 | ResourceFieldSelector :

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In the following example, we:
 -- examples/deploymentSimple.dhall
 
 let kubernetes =
-      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:d541487f153cee9890ebe4145bae8899e91cd81e2f4a5b65b06dfc325fb1ae7e
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let deployment =
       kubernetes.Deployment::{
@@ -64,7 +64,7 @@ let deployment =
           }
         , replicas = Some 2
         , template = kubernetes.PodTemplateSpec::{
-          , metadata = kubernetes.ObjectMeta::{ name = Some "nginx" }
+          , metadata = Some kubernetes.ObjectMeta::{ name = Some "nginx" }
           , spec = Some kubernetes.PodSpec::{
             , containers =
               [ kubernetes.Container::{
@@ -148,7 +148,7 @@ let Prelude =
 let map = Prelude.List.map
 
 let kubernetes =
-      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:d541487f153cee9890ebe4145bae8899e91cd81e2f4a5b65b06dfc325fb1ae7e
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let Service = { name : Text, host : Text, version : Text }
 

--- a/examples/aws-iam-authenticator-chart.dhall
+++ b/examples/aws-iam-authenticator-chart.dhall
@@ -1,5 +1,5 @@
 let kubernetes =
-      ../package.dhall sha256:d541487f153cee9890ebe4145bae8899e91cd81e2f4a5b65b06dfc325fb1ae7e
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let release = "wintering-rodent"
 
@@ -26,7 +26,7 @@ in  kubernetes.DaemonSet::{
         , type = Some "RollingUpdate"
         }
       , template = kubernetes.PodTemplateSpec::{
-        , metadata = kubernetes.ObjectMeta::{
+        , metadata = Some kubernetes.ObjectMeta::{
           , name = Some name
           , annotations = Some
               (toMap { `scheduler.alpha.kubernetes.io/critical-pod` = "" })

--- a/examples/deployment.dhall
+++ b/examples/deployment.dhall
@@ -2,7 +2,7 @@ let Prelude =
       ../Prelude.dhall sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e
 
 let kubernetes =
-      ../package.dhall sha256:d541487f153cee9890ebe4145bae8899e91cd81e2f4a5b65b06dfc325fb1ae7e
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let deployment =
       kubernetes.Deployment::{
@@ -21,7 +21,7 @@ let deployment =
             }
           }
         , template = kubernetes.PodTemplateSpec::{
-          , metadata = kubernetes.ObjectMeta::{
+          , metadata = Some kubernetes.ObjectMeta::{
             , name = Some "nginx"
             , labels = Some (toMap { app = "nginx" })
             }

--- a/examples/deploymentSimple.dhall
+++ b/examples/deploymentSimple.dhall
@@ -1,5 +1,5 @@
 let kubernetes =
-      ../package.dhall sha256:d541487f153cee9890ebe4145bae8899e91cd81e2f4a5b65b06dfc325fb1ae7e
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let deployment =
       kubernetes.Deployment::{
@@ -10,7 +10,7 @@ let deployment =
           }
         , replicas = Some 2
         , template = kubernetes.PodTemplateSpec::{
-          , metadata = kubernetes.ObjectMeta::{ name = Some "nginx" }
+          , metadata = Some kubernetes.ObjectMeta::{ name = Some "nginx" }
           , spec = Some kubernetes.PodSpec::{
             , containers =
               [ kubernetes.Container::{

--- a/examples/ingress.dhall
+++ b/examples/ingress.dhall
@@ -4,7 +4,7 @@ let Prelude =
 let map = Prelude.List.map
 
 let kubernetes =
-      ../package.dhall sha256:d541487f153cee9890ebe4145bae8899e91cd81e2f4a5b65b06dfc325fb1ae7e
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let Service = { name : Text, host : Text, version : Text }
 

--- a/examples/service.dhall
+++ b/examples/service.dhall
@@ -2,7 +2,7 @@ let Prelude =
       ../Prelude.dhall sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e
 
 let kubernetes =
-      ../package.dhall sha256:d541487f153cee9890ebe4145bae8899e91cd81e2f4a5b65b06dfc325fb1ae7e
+      ../package.dhall sha256:3ae2db78413714b7f7c5b2b3d92c78599a2be8e5371f567593eb0b3170c57656
 
 let spec =
       { selector = Some (toMap { app = "nginx" })

--- a/nix/dhall-haskell.json
+++ b/nix/dhall-haskell.json
@@ -1,7 +1,10 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "f28409922caed49f0da36010aa085e559fa82430",
-  "date": "2020-10-30T18:18:01-07:00",
-  "sha256": "1xrlh6yvdz3xvnsjdl4h5rqb044p58xc3haq2zrgn106nbna17y2",
-  "fetchSubmodules": true
+  "rev": "4d3bb4784908f4ddb63ee70946a84fa967ca9733",
+  "date": "2021-01-09T11:53:46-08:00",
+  "path": "/nix/store/mwnpiz53im9xlqp2vx1kz5553siz2nx0-dhall-haskell",
+  "sha256": "0mdhfi8j2ypd5804p0fv5rbzrmbh4w0bjhq77nymv6d8hvq3chzw",
+  "fetchSubmodules": true,
+  "deepClone": false,
+  "leaveDotGit": false
 }

--- a/nix/kubernetes/1.14.txt
+++ b/nix/kubernetes/1.14.txt
@@ -1,1 +1,1 @@
-102qc71dlqpkslj30rhk71m7val2wxlpr8byvkjyk7l1mq0f7k3w
+0z2chn8dqinc6cpyl9w1f3rn77qfxbbgzmrcvzal18a8pzd5rkcy

--- a/nix/kubernetes/1.14.txt
+++ b/nix/kubernetes/1.14.txt
@@ -1,1 +1,1 @@
-0z2chn8dqinc6cpyl9w1f3rn77qfxbbgzmrcvzal18a8pzd5rkcy
+102qc71dlqpkslj30rhk71m7val2wxlpr8byvkjyk7l1mq0f7k3w

--- a/nix/kubernetes/1.15.txt
+++ b/nix/kubernetes/1.15.txt
@@ -1,1 +1,1 @@
-1gwvlflf0yha1qsv6lp1skqpbm22qiyc5bicp6s1w8rxz8wlcv91
+1xi676jql0akwxwlh4bz95zqz042xzaigz1dqf64dhqz0dvrd395

--- a/nix/kubernetes/1.15.txt
+++ b/nix/kubernetes/1.15.txt
@@ -1,1 +1,1 @@
-1xi676jql0akwxwlh4bz95zqz042xzaigz1dqf64dhqz0dvrd395
+1gwvlflf0yha1qsv6lp1skqpbm22qiyc5bicp6s1w8rxz8wlcv91

--- a/nix/kubernetes/1.16.txt
+++ b/nix/kubernetes/1.16.txt
@@ -1,1 +1,1 @@
-01m3pcymbfg7vzdx9z08iilqlfn8w5myw6rlf4mjny76x380d94x
+0qi6gp6jd5za8j5p5yv6fs784r5nglz14xcrkmij3hy86azk7qnl

--- a/nix/kubernetes/1.16.txt
+++ b/nix/kubernetes/1.16.txt
@@ -1,1 +1,1 @@
-0qi6gp6jd5za8j5p5yv6fs784r5nglz14xcrkmij3hy86azk7qnl
+01m3pcymbfg7vzdx9z08iilqlfn8w5myw6rlf4mjny76x380d94x

--- a/nix/kubernetes/1.17.txt
+++ b/nix/kubernetes/1.17.txt
@@ -1,1 +1,1 @@
-0jqy93vcsn3fcc7r2dgb5vpbii2gm6d2m4kr0jlblr7ii92fr7as
+0q84xf16dl15s30awirsg73y9fbd9n6sr6163xvyjq5x8vf9axgj

--- a/nix/kubernetes/1.17.txt
+++ b/nix/kubernetes/1.17.txt
@@ -1,1 +1,1 @@
-0q84xf16dl15s30awirsg73y9fbd9n6sr6163xvyjq5x8vf9axgj
+0jqy93vcsn3fcc7r2dgb5vpbii2gm6d2m4kr0jlblr7ii92fr7as

--- a/nix/kubernetes/1.17.txt
+++ b/nix/kubernetes/1.17.txt
@@ -1,1 +1,1 @@
-0q84xf16dl15s30awirsg73y9fbd9n6sr6163xvyjq5x8vf9axgj
+0qw75qr2rm7x9pf2b8dg8p5lyl7xhvj7ww8s5nvf6gx6vswkp4rs

--- a/nix/kubernetes/1.18.txt
+++ b/nix/kubernetes/1.18.txt
@@ -1,1 +1,1 @@
-17df2mk4xr84iqi4wlb26irfk16lw298s1lxkib7bl61sqa01i6q
+1vri2xhypjb1y9zc307nnrylqwpcrksydjv9grqw2ikfdhbz01y4

--- a/nix/kubernetes/1.18.txt
+++ b/nix/kubernetes/1.18.txt
@@ -1,1 +1,1 @@
-1vri2xhypjb1y9zc307nnrylqwpcrksydjv9grqw2ikfdhbz01y4
+1041i6ayba3wi5mg4smk1zzjm3dkx86avhcagl0rwrikh81lcvwx

--- a/nix/kubernetes/1.18.txt
+++ b/nix/kubernetes/1.18.txt
@@ -1,1 +1,1 @@
-1vri2xhypjb1y9zc307nnrylqwpcrksydjv9grqw2ikfdhbz01y4
+17df2mk4xr84iqi4wlb26irfk16lw298s1lxkib7bl61sqa01i6q

--- a/nix/kubernetes/1.19.txt
+++ b/nix/kubernetes/1.19.txt
@@ -1,1 +1,1 @@
-038kzh123c8wlxkxmn2y0zpvxp38vkfvva8g7am9rs8543d2wd1a
+1xsfba1f9mkdsg1748j7sszz984lvvc7c7an02f3ankjzbpglcch

--- a/nix/kubernetes/1.19.txt
+++ b/nix/kubernetes/1.19.txt
@@ -1,1 +1,1 @@
-1xsfba1f9mkdsg1748j7sszz984lvvc7c7an02f3ankjzbpglcch
+038kzh123c8wlxkxmn2y0zpvxp38vkfvva8g7am9rs8543d2wd1a

--- a/nix/kubernetes/1.19.txt
+++ b/nix/kubernetes/1.19.txt
@@ -1,1 +1,1 @@
-038kzh123c8wlxkxmn2y0zpvxp38vkfvva8g7am9rs8543d2wd1a
+02qi2dlsd9k8rjcnrps31ncrc3gcxmb2vdrcq58k292d7590h5n6


### PR DESCRIPTION
Updated dhall-openapi to include changes in https://github.com/dhall-lang/dhall-haskell/pull/2128, and regenerate all of the configuration.

This introduces breaking changes in the generated dhall config.