### PR TITLE
Only attempt to copy examples for preferred version

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -21,11 +21,11 @@ if DIR=$(nix-build release.nix --attr "\"${VERSION}\"" --no-out-link); then
   chmod -R u+w "${BASE}/types"
   cp -r "${DIR}/schemas" "${BASE}"
   chmod -R u+w "${BASE}/schemas"
-  cp -r "${DIR}/examples" "${BASE}"
-  chmod -R u+w "${BASE}/examples"
   cp "${DIR}/types.dhall" "${DIR}/typesUnion.dhall" "${DIR}/defaults.dhall" "${DIR}/schemas.dhall" "${DIR}/package.dhall" "${BASE}"
   chmod u+w "${BASE}/types.dhall" "${BASE}/typesUnion.dhall" "${BASE}/defaults.dhall" "${BASE}/schemas.dhall" "${BASE}/package.dhall"
   if [ "${VERSION}" == "${PREFERRED_VERSION}" ]; then
+    cp -r "${DIR}/examples" "${BASE}"
+    chmod -R u+w "${BASE}/examples"
     cp "${DIR}/Prelude.dhall" "${DIR}/README.md" "${BASE}"
     chmod u+w "${BASE}/Prelude.dhall" "${BASE}/README.md"
   fi


### PR DESCRIPTION
These files are only copied into the nix build for the preferred
version, so for all other versions `cp` would complain that these
files do not exist.