### PR TITLE
Upgrade `dhall-haskell`

### DIFF
--- a/1.23/defaults.dhall
+++ b/1.23/defaults.dhall
@@ -191,76 +191,76 @@
     ./defaults/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:378366369e27427f71184050ac6666edc8c423954510952d39248ebce88acc42
 , ContainerResourceMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ContainerResourceMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , CrossVersionObjectReference =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ExternalMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ExternalMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , HPAScalingPolicy =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , HPAScalingRules =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:2df1d7fbfb879b193f09e8045d0bb7931fd1dccbf8bceef55a1bf17f69328f98
 , HorizontalPodAutoscaler =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:0cf7649562e8d506995500ac9d25f3b5cd760c57876406032dad66bd143a29de
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:4c43505a237707cd5a115fd7a0e02bd991b03e21fbd520ecd80dddce19a3e3ad
 , HorizontalPodAutoscalerBehavior =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:33a2d384b965bae8dbd1f5c746a075a1ac7c3c855cf65efb31fe392b86deb626
 , HorizontalPodAutoscalerCondition =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , HorizontalPodAutoscalerList =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:1663ce1abf28543263d0f6f572c51b8d84449674d33d84feb702ebf8c8761145
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:e73002ff3362f3ad753a59819546e516789338cd5ecd971037762679150658ad
 , HorizontalPodAutoscalerSpec =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:2dfea72d3ad77df1d052736afa7c73d9c3b8186f9afa4a81972ea790a05e8b7d
 , HorizontalPodAutoscalerStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:15a425eb07408a4a160a3291770f72ced0bb58c829ae599d4ffd475d9427c2c3
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:7033a28e2dc666d82fe56df0739fcbdc5c1df5fb4954e01df8c7684d2d0268fe
 , MetricIdentifier =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:ff0e0e9c4fcd3a099f08ac65793ca1ca6152467acd72c3709d4227a4621f60f9
 , MetricSpec =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:f69b8a5ee2a891287c799b20c0eb153641e3094716bff9df4397cb702f58b6dd
 , MetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:842bb70f6f25179aabceb6b45d9d5b2b80410c016a8954732ed35c9cb8ba2330
 , MetricTarget =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:5a8d96e3b4724d60808b6e21a8a4d7a2e59303fe762edfddc10a79588da3e922
 , MetricValueStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:5a8d96e3b4724d60808b6e21a8a4d7a2e59303fe762edfddc10a79588da3e922
 , ObjectMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ObjectMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , PodsMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , PodsMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ResourceMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ResourceMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , CronJob =
     ./defaults/io.k8s.api.batch.v1.CronJob.dhall

--- a/1.23/package.dhall
+++ b/1.23/package.dhall
@@ -1,14 +1,14 @@
   ./schemas.dhall
-    sha256:51935aaec2a05902ec764b67523de18e5662630f0c890fe151d983c29ec573bf
+    sha256:c880f34dd269c0311f95d0f7bc37a24614712b39782c6848cf55067d24d13c00
 ∧ { IntOrString =
       ( ./types.dhall
-          sha256:afb6a176a5b3d320eab29bc157c79dcc1200ff5b6278594503ebd47fd0ae76f6
+          sha256:ac5a4a9f3d97cceff148f7443d4a488003aa7c0f791c3802a6dac4c4a8e89308
       ).IntOrString
   , NatOrString =
       ( ./types.dhall
-          sha256:afb6a176a5b3d320eab29bc157c79dcc1200ff5b6278594503ebd47fd0ae76f6
+          sha256:ac5a4a9f3d97cceff148f7443d4a488003aa7c0f791c3802a6dac4c4a8e89308
       ).NatOrString
   , Resource =
       ./typesUnion.dhall
-        sha256:add0845f010721707c3cbd4095c48bcfce478f0c61b394f6a80a97183ff6c0d6
+        sha256:7b4b51af1a841a7efd6403068e1001468e2f7d5e1bf5fdb53c7bccefe2ea7801
   }

--- a/1.23/schemas.dhall
+++ b/1.23/schemas.dhall
@@ -191,76 +191,76 @@
     ./schemas/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:e18f9c9a292543e64df19c0de89e8f25c726d3cba0a90d2d21af7594312362b1
 , ContainerResourceMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:36ff1bee1c3459f052794978a1273fa93651577fe16cbc1bf9487f0b2ddba0c7
 , ContainerResourceMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:3eefa7925d8eba0567f5d5568fa315976e35160d4ab6f3623eb6dd85f9ccddaf
 , CrossVersionObjectReference =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:61ee2b43f8d51e3222dc6d83316419779f3a36b98042ae712460a19cd86a2347
 , ExternalMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:2f0cec3e2fffe0fea5844aee4958f2b7091deddd3b634cd964f5cdb2244bc94d
 , ExternalMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:26c313df8a9fa25c943f326eefd4d49d781261e9c649543cf238533297c1a310
 , HPAScalingPolicy =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:acde7200c0df249cd86bdbe36d4c064027b247e90c9865e3005792a7a19bdf72
 , HPAScalingRules =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:e45bf4e3d80958bab5ab6e79b3dfc3ba49c2e30d5a23c955dcf5b872058cfd22
 , HorizontalPodAutoscaler =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:b038008385699280260fbf6d454e25b5935ebc95bf508839fc02240eff159579
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:b42055c2fb098dfb9b9323b8b2af8d97c0f4aaf89073a093a00eae6de4ad1221
 , HorizontalPodAutoscalerBehavior =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:6f774597465dd56c7dad19120e1a9bd5c1ade02f4873b63a680a8aaea7eef85b
 , HorizontalPodAutoscalerCondition =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , HorizontalPodAutoscalerList =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:3eccf85524015e4b04236e19d55ea92475521bbf876373812530ad6171b876bc
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:0146c687bec26f88b2f05f72ac3f68f76aa17b764a04c7f433b749daadd888e2
 , HorizontalPodAutoscalerSpec =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:65a8cf241c397235a0d8d9523a54edc00f18ee65f853f1b0c5089bc7211e6f5e
 , HorizontalPodAutoscalerStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:bd66c21adea02eec8de311f03ce19ebad46f1f5cf04e9c513826b4f0baa4058e
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:45a7b51f19d52edc9f4668c2b39f216fde647354a05ba9c06515439408a9a61b
 , MetricIdentifier =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:bea4e0cd6bbe33da199a60ba9e64a127f2efade2f28d2ad21195ee352dd82f6f
 , MetricSpec =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:14d8364ea2a65676a8047a552bc2dfd20c1442478502cebdece7ae6198ea03e2
 , MetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:2696496da6abf3ac323f6495e91caa9741fe2cad43599371a3926d3d3c1694a9
 , MetricTarget =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:59aa69e80c7c4f0efc048a98fd1f5bd3b1fd7f2ab430ef2bd3437ded47cfe697
 , MetricValueStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:9f227712e34f51bf0cd1c70f826a62d9d890c506aec443ffd9438a27c154c8d6
 , ObjectMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:350b8d92a2af651d36a2965596a17ca8e0b106c1ed488a88416b12dbb9f9fd13
 , ObjectMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:1577255093301f34275a36912b13a5447409b5f15766b02d7e6c447e49bc3af5
 , PodsMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:2f0cec3e2fffe0fea5844aee4958f2b7091deddd3b634cd964f5cdb2244bc94d
 , PodsMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:26c313df8a9fa25c943f326eefd4d49d781261e9c649543cf238533297c1a310
 , ResourceMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:2541c66165e60d23503f846acb31dd67b371114819be19bc006df4369c9da13d
 , ResourceMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , CronJob =
     ./schemas/io.k8s.api.batch.v1.CronJob.dhall

--- a/1.23/types.dhall
+++ b/1.23/types.dhall
@@ -194,76 +194,76 @@
     ./types/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:d76d78afa568044a4282306ada81504a5d800bc79be897cef1d388fc40903cdb
 , ContainerResourceMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:d761dd52e0d1d11ab9ffb28979fa2ff7e01051b1b08ab3624810e7048a653686
 , ContainerResourceMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:767b644ff3d3493573fa7fb4337b766a9e8fcb092b70c03e29424110615ec7bd
 , CrossVersionObjectReference =
-    ./types/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./types/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
 , ExternalMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 , ExternalMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 , HPAScalingPolicy =
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:5792aa8931dc20e3fbb0fbc7b90ac64b3d6699c27d80177168188426c6e4b2b0
 , HPAScalingRules =
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:83f98e95649ea8cc44556dba95e71ef6e9ffee78a5ed0de47d652ed81661905a
 , HorizontalPodAutoscaler =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:56d6fe88f562e56553dd8adbe0b0ae2cf7f3923adbe505eacb7cbefdf5bc5387
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:c1bbcb5ed71ab115ab0ae3e7e3dce936ab61454bf3225dbf7fcbc36a5f876025
 , HorizontalPodAutoscalerBehavior =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:78306e919b5a909c2c4bf5724963f36aea3fc948fd41be8fe4404963bd424e9c
 , HorizontalPodAutoscalerCondition =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , HorizontalPodAutoscalerList =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:bc52b10f835b3a74cae7dec63f3e0db0ae6c760fd653e0920a8ef1f5eb02479e
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:8ff4f2e826824d10780d2a18e9f9783bda6fac8900da7fbd19e09d736cd63e6f
 , HorizontalPodAutoscalerSpec =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:b0e129dc0cb6ea27cb54b6e96f2aa0dfdff0914b03cfa7758c8f218552b45386
 , HorizontalPodAutoscalerStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:675d444e0ddc06a7bf0b3b4d4d28394d0c6ac670a7331ac51848896ff571fe82
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:a8c411695d82de0e89f9dc66a256e075410629a2caf6a39314d31a45581a2f84
 , MetricIdentifier =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:741008bebbc428229112067a8b8ce6e2e14999cd879329648d9de3b46a24323f
 , MetricSpec =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:6cba72b61855a81623f01466169a6ded6f89d5b838b1644991daac284bb0e536
 , MetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:18b773c6aed1cb379b13b9425d8b56bfd881a6e167f77de96ebc3742fa30578a
 , MetricTarget =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:d4d74e0604de0d8f2f8aaca8effd873d84d2c1713b2715a6fbac77f3c77121f5
 , MetricValueStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:727bb14d4e87444e89ddba893b699c36600c6758ba0546ea468a61c4a2791d59
 , ObjectMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:5b41279b44559ad98a1b79c3d5c5c7a9b5056f80ac44ab84f5dae89f35a5f1d6
 , ObjectMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9cc9ccb303bee6e50625a232ed6e385e23c9055ef7ab6449dc66313014bd6e53
 , PodsMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 , PodsMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 , ResourceMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9348a553be2edd12c07b60261e671d694617b2288451f8644b09f003ccc2c47b
 , ResourceMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , CronJob =
     ./types/io.k8s.api.batch.v1.CronJob.dhall

--- a/1.23/typesUnion.dhall
+++ b/1.23/typesUnion.dhall
@@ -194,76 +194,76 @@
     ./types/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:d76d78afa568044a4282306ada81504a5d800bc79be897cef1d388fc40903cdb
 | ContainerResourceMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:d761dd52e0d1d11ab9ffb28979fa2ff7e01051b1b08ab3624810e7048a653686
 | ContainerResourceMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:767b644ff3d3493573fa7fb4337b766a9e8fcb092b70c03e29424110615ec7bd
 | CrossVersionObjectReference :
-    ./types/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./types/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
 | ExternalMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 | ExternalMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 | HPAScalingPolicy :
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:5792aa8931dc20e3fbb0fbc7b90ac64b3d6699c27d80177168188426c6e4b2b0
 | HPAScalingRules :
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:83f98e95649ea8cc44556dba95e71ef6e9ffee78a5ed0de47d652ed81661905a
 | HorizontalPodAutoscaler :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:56d6fe88f562e56553dd8adbe0b0ae2cf7f3923adbe505eacb7cbefdf5bc5387
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:c1bbcb5ed71ab115ab0ae3e7e3dce936ab61454bf3225dbf7fcbc36a5f876025
 | HorizontalPodAutoscalerBehavior :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:78306e919b5a909c2c4bf5724963f36aea3fc948fd41be8fe4404963bd424e9c
 | HorizontalPodAutoscalerCondition :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | HorizontalPodAutoscalerList :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:bc52b10f835b3a74cae7dec63f3e0db0ae6c760fd653e0920a8ef1f5eb02479e
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:8ff4f2e826824d10780d2a18e9f9783bda6fac8900da7fbd19e09d736cd63e6f
 | HorizontalPodAutoscalerSpec :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:b0e129dc0cb6ea27cb54b6e96f2aa0dfdff0914b03cfa7758c8f218552b45386
 | HorizontalPodAutoscalerStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:675d444e0ddc06a7bf0b3b4d4d28394d0c6ac670a7331ac51848896ff571fe82
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:a8c411695d82de0e89f9dc66a256e075410629a2caf6a39314d31a45581a2f84
 | MetricIdentifier :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:741008bebbc428229112067a8b8ce6e2e14999cd879329648d9de3b46a24323f
 | MetricSpec :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:6cba72b61855a81623f01466169a6ded6f89d5b838b1644991daac284bb0e536
 | MetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:18b773c6aed1cb379b13b9425d8b56bfd881a6e167f77de96ebc3742fa30578a
 | MetricTarget :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:d4d74e0604de0d8f2f8aaca8effd873d84d2c1713b2715a6fbac77f3c77121f5
 | MetricValueStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:727bb14d4e87444e89ddba893b699c36600c6758ba0546ea468a61c4a2791d59
 | ObjectMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:5b41279b44559ad98a1b79c3d5c5c7a9b5056f80ac44ab84f5dae89f35a5f1d6
 | ObjectMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9cc9ccb303bee6e50625a232ed6e385e23c9055ef7ab6449dc66313014bd6e53
 | PodsMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 | PodsMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 | ResourceMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9348a553be2edd12c07b60261e671d694617b2288451f8644b09f003ccc2c47b
 | ResourceMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | CronJob :
     ./types/io.k8s.api.batch.v1.CronJob.dhall

--- a/1.24/defaults.dhall
+++ b/1.24/defaults.dhall
@@ -191,76 +191,76 @@
     ./defaults/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:378366369e27427f71184050ac6666edc8c423954510952d39248ebce88acc42
 , ContainerResourceMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ContainerResourceMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , CrossVersionObjectReference =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ExternalMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ExternalMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , HPAScalingPolicy =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , HPAScalingRules =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:2df1d7fbfb879b193f09e8045d0bb7931fd1dccbf8bceef55a1bf17f69328f98
 , HorizontalPodAutoscaler =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:0cf7649562e8d506995500ac9d25f3b5cd760c57876406032dad66bd143a29de
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:4c43505a237707cd5a115fd7a0e02bd991b03e21fbd520ecd80dddce19a3e3ad
 , HorizontalPodAutoscalerBehavior =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:33a2d384b965bae8dbd1f5c746a075a1ac7c3c855cf65efb31fe392b86deb626
 , HorizontalPodAutoscalerCondition =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , HorizontalPodAutoscalerList =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:1663ce1abf28543263d0f6f572c51b8d84449674d33d84feb702ebf8c8761145
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:e73002ff3362f3ad753a59819546e516789338cd5ecd971037762679150658ad
 , HorizontalPodAutoscalerSpec =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:2dfea72d3ad77df1d052736afa7c73d9c3b8186f9afa4a81972ea790a05e8b7d
 , HorizontalPodAutoscalerStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:15a425eb07408a4a160a3291770f72ced0bb58c829ae599d4ffd475d9427c2c3
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:7033a28e2dc666d82fe56df0739fcbdc5c1df5fb4954e01df8c7684d2d0268fe
 , MetricIdentifier =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:ff0e0e9c4fcd3a099f08ac65793ca1ca6152467acd72c3709d4227a4621f60f9
 , MetricSpec =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:f69b8a5ee2a891287c799b20c0eb153641e3094716bff9df4397cb702f58b6dd
 , MetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:842bb70f6f25179aabceb6b45d9d5b2b80410c016a8954732ed35c9cb8ba2330
 , MetricTarget =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:5a8d96e3b4724d60808b6e21a8a4d7a2e59303fe762edfddc10a79588da3e922
 , MetricValueStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:5a8d96e3b4724d60808b6e21a8a4d7a2e59303fe762edfddc10a79588da3e922
 , ObjectMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ObjectMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , PodsMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , PodsMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ResourceMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ResourceMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , CronJob =
     ./defaults/io.k8s.api.batch.v1.CronJob.dhall

--- a/1.24/package.dhall
+++ b/1.24/package.dhall
@@ -1,14 +1,14 @@
   ./schemas.dhall
-    sha256:59a3611386e9276d18288a120501202961e82c73491193f3f3807497c60b83c6
+    sha256:646ad389f75a0370823a4760b8c06b0e2d55d53f9dfb47f80c9cd4a368cddc9d
 ∧ { IntOrString =
       ( ./types.dhall
-          sha256:ca814de409cb323086854b4342df86afcadad9d95684107c93862dff124cd4cb
+          sha256:0f77b8b9edb303bc080982980f228d1d34808e7e8cb1d2a17d28bcc66c11d011
       ).IntOrString
   , NatOrString =
       ( ./types.dhall
-          sha256:ca814de409cb323086854b4342df86afcadad9d95684107c93862dff124cd4cb
+          sha256:0f77b8b9edb303bc080982980f228d1d34808e7e8cb1d2a17d28bcc66c11d011
       ).NatOrString
   , Resource =
       ./typesUnion.dhall
-        sha256:1f1868abf1a21ad2e24a73d3a19a48602e2d35d800dd96b08d01b2873530464d
+        sha256:64df1e198c91a8da47b575ad090c9811c046a1e953763e504e02890957d2cdc2
   }

--- a/1.24/schemas.dhall
+++ b/1.24/schemas.dhall
@@ -191,76 +191,76 @@
     ./schemas/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:e18f9c9a292543e64df19c0de89e8f25c726d3cba0a90d2d21af7594312362b1
 , ContainerResourceMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:36ff1bee1c3459f052794978a1273fa93651577fe16cbc1bf9487f0b2ddba0c7
 , ContainerResourceMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:3eefa7925d8eba0567f5d5568fa315976e35160d4ab6f3623eb6dd85f9ccddaf
 , CrossVersionObjectReference =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:61ee2b43f8d51e3222dc6d83316419779f3a36b98042ae712460a19cd86a2347
 , ExternalMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:2f0cec3e2fffe0fea5844aee4958f2b7091deddd3b634cd964f5cdb2244bc94d
 , ExternalMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:26c313df8a9fa25c943f326eefd4d49d781261e9c649543cf238533297c1a310
 , HPAScalingPolicy =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:acde7200c0df249cd86bdbe36d4c064027b247e90c9865e3005792a7a19bdf72
 , HPAScalingRules =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:e45bf4e3d80958bab5ab6e79b3dfc3ba49c2e30d5a23c955dcf5b872058cfd22
 , HorizontalPodAutoscaler =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:b038008385699280260fbf6d454e25b5935ebc95bf508839fc02240eff159579
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:b42055c2fb098dfb9b9323b8b2af8d97c0f4aaf89073a093a00eae6de4ad1221
 , HorizontalPodAutoscalerBehavior =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:6f774597465dd56c7dad19120e1a9bd5c1ade02f4873b63a680a8aaea7eef85b
 , HorizontalPodAutoscalerCondition =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , HorizontalPodAutoscalerList =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:3eccf85524015e4b04236e19d55ea92475521bbf876373812530ad6171b876bc
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:0146c687bec26f88b2f05f72ac3f68f76aa17b764a04c7f433b749daadd888e2
 , HorizontalPodAutoscalerSpec =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:65a8cf241c397235a0d8d9523a54edc00f18ee65f853f1b0c5089bc7211e6f5e
 , HorizontalPodAutoscalerStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:bd66c21adea02eec8de311f03ce19ebad46f1f5cf04e9c513826b4f0baa4058e
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:45a7b51f19d52edc9f4668c2b39f216fde647354a05ba9c06515439408a9a61b
 , MetricIdentifier =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:bea4e0cd6bbe33da199a60ba9e64a127f2efade2f28d2ad21195ee352dd82f6f
 , MetricSpec =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:14d8364ea2a65676a8047a552bc2dfd20c1442478502cebdece7ae6198ea03e2
 , MetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:2696496da6abf3ac323f6495e91caa9741fe2cad43599371a3926d3d3c1694a9
 , MetricTarget =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:59aa69e80c7c4f0efc048a98fd1f5bd3b1fd7f2ab430ef2bd3437ded47cfe697
 , MetricValueStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:9f227712e34f51bf0cd1c70f826a62d9d890c506aec443ffd9438a27c154c8d6
 , ObjectMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:350b8d92a2af651d36a2965596a17ca8e0b106c1ed488a88416b12dbb9f9fd13
 , ObjectMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:1577255093301f34275a36912b13a5447409b5f15766b02d7e6c447e49bc3af5
 , PodsMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:2f0cec3e2fffe0fea5844aee4958f2b7091deddd3b634cd964f5cdb2244bc94d
 , PodsMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:26c313df8a9fa25c943f326eefd4d49d781261e9c649543cf238533297c1a310
 , ResourceMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:2541c66165e60d23503f846acb31dd67b371114819be19bc006df4369c9da13d
 , ResourceMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , CronJob =
     ./schemas/io.k8s.api.batch.v1.CronJob.dhall

--- a/1.24/types.dhall
+++ b/1.24/types.dhall
@@ -194,76 +194,76 @@
     ./types/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:d76d78afa568044a4282306ada81504a5d800bc79be897cef1d388fc40903cdb
 , ContainerResourceMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:d761dd52e0d1d11ab9ffb28979fa2ff7e01051b1b08ab3624810e7048a653686
 , ContainerResourceMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:767b644ff3d3493573fa7fb4337b766a9e8fcb092b70c03e29424110615ec7bd
 , CrossVersionObjectReference =
-    ./types/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./types/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
 , ExternalMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 , ExternalMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 , HPAScalingPolicy =
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:5792aa8931dc20e3fbb0fbc7b90ac64b3d6699c27d80177168188426c6e4b2b0
 , HPAScalingRules =
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:83f98e95649ea8cc44556dba95e71ef6e9ffee78a5ed0de47d652ed81661905a
 , HorizontalPodAutoscaler =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:56d6fe88f562e56553dd8adbe0b0ae2cf7f3923adbe505eacb7cbefdf5bc5387
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:c1bbcb5ed71ab115ab0ae3e7e3dce936ab61454bf3225dbf7fcbc36a5f876025
 , HorizontalPodAutoscalerBehavior =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:78306e919b5a909c2c4bf5724963f36aea3fc948fd41be8fe4404963bd424e9c
 , HorizontalPodAutoscalerCondition =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , HorizontalPodAutoscalerList =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:bc52b10f835b3a74cae7dec63f3e0db0ae6c760fd653e0920a8ef1f5eb02479e
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:8ff4f2e826824d10780d2a18e9f9783bda6fac8900da7fbd19e09d736cd63e6f
 , HorizontalPodAutoscalerSpec =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:b0e129dc0cb6ea27cb54b6e96f2aa0dfdff0914b03cfa7758c8f218552b45386
 , HorizontalPodAutoscalerStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:675d444e0ddc06a7bf0b3b4d4d28394d0c6ac670a7331ac51848896ff571fe82
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:a8c411695d82de0e89f9dc66a256e075410629a2caf6a39314d31a45581a2f84
 , MetricIdentifier =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:741008bebbc428229112067a8b8ce6e2e14999cd879329648d9de3b46a24323f
 , MetricSpec =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:6cba72b61855a81623f01466169a6ded6f89d5b838b1644991daac284bb0e536
 , MetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:18b773c6aed1cb379b13b9425d8b56bfd881a6e167f77de96ebc3742fa30578a
 , MetricTarget =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:d4d74e0604de0d8f2f8aaca8effd873d84d2c1713b2715a6fbac77f3c77121f5
 , MetricValueStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:727bb14d4e87444e89ddba893b699c36600c6758ba0546ea468a61c4a2791d59
 , ObjectMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:5b41279b44559ad98a1b79c3d5c5c7a9b5056f80ac44ab84f5dae89f35a5f1d6
 , ObjectMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9cc9ccb303bee6e50625a232ed6e385e23c9055ef7ab6449dc66313014bd6e53
 , PodsMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 , PodsMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 , ResourceMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9348a553be2edd12c07b60261e671d694617b2288451f8644b09f003ccc2c47b
 , ResourceMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , CronJob =
     ./types/io.k8s.api.batch.v1.CronJob.dhall

--- a/1.24/typesUnion.dhall
+++ b/1.24/typesUnion.dhall
@@ -194,76 +194,76 @@
     ./types/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:d76d78afa568044a4282306ada81504a5d800bc79be897cef1d388fc40903cdb
 | ContainerResourceMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:d761dd52e0d1d11ab9ffb28979fa2ff7e01051b1b08ab3624810e7048a653686
 | ContainerResourceMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:767b644ff3d3493573fa7fb4337b766a9e8fcb092b70c03e29424110615ec7bd
 | CrossVersionObjectReference :
-    ./types/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./types/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
 | ExternalMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 | ExternalMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 | HPAScalingPolicy :
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:5792aa8931dc20e3fbb0fbc7b90ac64b3d6699c27d80177168188426c6e4b2b0
 | HPAScalingRules :
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:83f98e95649ea8cc44556dba95e71ef6e9ffee78a5ed0de47d652ed81661905a
 | HorizontalPodAutoscaler :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:56d6fe88f562e56553dd8adbe0b0ae2cf7f3923adbe505eacb7cbefdf5bc5387
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:c1bbcb5ed71ab115ab0ae3e7e3dce936ab61454bf3225dbf7fcbc36a5f876025
 | HorizontalPodAutoscalerBehavior :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:78306e919b5a909c2c4bf5724963f36aea3fc948fd41be8fe4404963bd424e9c
 | HorizontalPodAutoscalerCondition :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | HorizontalPodAutoscalerList :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:bc52b10f835b3a74cae7dec63f3e0db0ae6c760fd653e0920a8ef1f5eb02479e
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:8ff4f2e826824d10780d2a18e9f9783bda6fac8900da7fbd19e09d736cd63e6f
 | HorizontalPodAutoscalerSpec :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:b0e129dc0cb6ea27cb54b6e96f2aa0dfdff0914b03cfa7758c8f218552b45386
 | HorizontalPodAutoscalerStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:675d444e0ddc06a7bf0b3b4d4d28394d0c6ac670a7331ac51848896ff571fe82
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:a8c411695d82de0e89f9dc66a256e075410629a2caf6a39314d31a45581a2f84
 | MetricIdentifier :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:741008bebbc428229112067a8b8ce6e2e14999cd879329648d9de3b46a24323f
 | MetricSpec :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:6cba72b61855a81623f01466169a6ded6f89d5b838b1644991daac284bb0e536
 | MetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:18b773c6aed1cb379b13b9425d8b56bfd881a6e167f77de96ebc3742fa30578a
 | MetricTarget :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:d4d74e0604de0d8f2f8aaca8effd873d84d2c1713b2715a6fbac77f3c77121f5
 | MetricValueStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:727bb14d4e87444e89ddba893b699c36600c6758ba0546ea468a61c4a2791d59
 | ObjectMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:5b41279b44559ad98a1b79c3d5c5c7a9b5056f80ac44ab84f5dae89f35a5f1d6
 | ObjectMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9cc9ccb303bee6e50625a232ed6e385e23c9055ef7ab6449dc66313014bd6e53
 | PodsMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 | PodsMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 | ResourceMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9348a553be2edd12c07b60261e671d694617b2288451f8644b09f003ccc2c47b
 | ResourceMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | CronJob :
     ./types/io.k8s.api.batch.v1.CronJob.dhall

--- a/1.25/defaults.dhall
+++ b/1.25/defaults.dhall
@@ -191,80 +191,80 @@
     ./defaults/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:378366369e27427f71184050ac6666edc8c423954510952d39248ebce88acc42
 , ContainerResourceMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ContainerResourceMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , CrossVersionObjectReference =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ExternalMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ExternalMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , HPAScalingPolicy =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , HPAScalingRules =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:2df1d7fbfb879b193f09e8045d0bb7931fd1dccbf8bceef55a1bf17f69328f98
 , HorizontalPodAutoscaler =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:0cf7649562e8d506995500ac9d25f3b5cd760c57876406032dad66bd143a29de
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:4c43505a237707cd5a115fd7a0e02bd991b03e21fbd520ecd80dddce19a3e3ad
 , HorizontalPodAutoscalerBehavior =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:33a2d384b965bae8dbd1f5c746a075a1ac7c3c855cf65efb31fe392b86deb626
 , HorizontalPodAutoscalerCondition =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
 , HorizontalPodAutoscalerList =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:1663ce1abf28543263d0f6f572c51b8d84449674d33d84feb702ebf8c8761145
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:e73002ff3362f3ad753a59819546e516789338cd5ecd971037762679150658ad
 , HorizontalPodAutoscalerSpec =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:2dfea72d3ad77df1d052736afa7c73d9c3b8186f9afa4a81972ea790a05e8b7d
 , HorizontalPodAutoscalerStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:15a425eb07408a4a160a3291770f72ced0bb58c829ae599d4ffd475d9427c2c3
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:7033a28e2dc666d82fe56df0739fcbdc5c1df5fb4954e01df8c7684d2d0268fe
 , MetricIdentifier =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:ff0e0e9c4fcd3a099f08ac65793ca1ca6152467acd72c3709d4227a4621f60f9
 , MetricSpec =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:f69b8a5ee2a891287c799b20c0eb153641e3094716bff9df4397cb702f58b6dd
 , MetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:842bb70f6f25179aabceb6b45d9d5b2b80410c016a8954732ed35c9cb8ba2330
 , MetricTarget =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:5a8d96e3b4724d60808b6e21a8a4d7a2e59303fe762edfddc10a79588da3e922
 , MetricValueStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:5a8d96e3b4724d60808b6e21a8a4d7a2e59303fe762edfddc10a79588da3e922
 , ObjectMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ObjectMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , PodsMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , PodsMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ResourceMetricSource =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ResourceMetricStatus =
-    ./defaults/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./defaults/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , CronJob =
     ./defaults/io.k8s.api.batch.v1.CronJob.dhall
-      sha256:184863116c5756dec9f60edcb353c8ec4e3156ad07818f87ca57bd2b8b22650d
+      sha256:a7564f48c070649047ca036518c64300d22272b8fd6ca9194aef0bdedf5ef169
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1.CronJobList.dhall
       sha256:d6fd6fd3d7ad351457cae2cb6e2375ac23a9c580777a1a210f6869763eaa2f6a
@@ -276,7 +276,7 @@
       sha256:c68ed687b5580fef3778bc5c18c86f5f9665b0994b7042e4ea12630c29bc3fd7
 , Job =
     ./defaults/io.k8s.api.batch.v1.Job.dhall
-      sha256:d84b6eb300f138c5e0f2cbd7ff0db049916e53b941c02cfe3e512c73e132f282
+      sha256:747595a1ce01b8278ff475f797f309bcd56e06277dc9b10027baab4f678e0006
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall
       sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
@@ -285,13 +285,13 @@
       sha256:75e1f5c7bee0245bb1592e892cc2fe4382273df957058f6e43514c8df0d3dea8
 , JobSpec =
     ./defaults/io.k8s.api.batch.v1.JobSpec.dhall
-      sha256:00980880766598075ae2fab500ddc8e14d92018c2fafea3cd9023ebd3ecf71dc
+      sha256:1a1044d7906f54eb07c5ec9472639c0eeb2a35019d375999c7221fa9063cf00c
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall
       sha256:7448977b44a145530865d0947624165be35fc1a6fc7d2ca7e7d07346ca85f5b2
 , JobTemplateSpec =
     ./defaults/io.k8s.api.batch.v1.JobTemplateSpec.dhall
-      sha256:aed603f55d76b20b19b3f5fa6d8e1ffcc52af6ebf38fca7fa3bc894f1713b991
+      sha256:ca9a468043790bd57bda23dafd2cc9f7869521647996a278456533ac83200a77
 , PodFailurePolicy =
     ./defaults/io.k8s.api.batch.v1.PodFailurePolicy.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
@@ -303,7 +303,7 @@
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , PodFailurePolicyRule =
     ./defaults/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
-      sha256:8dcb381b90ebfa90282ac50cf5519cf11baf89d56c173664096f889b556b5d50
+      sha256:cbd31096945c7ec703c6b10728c33533c631d6ee4b84a9bc47f641e3ee1ca9cf
 , UncountedTerminatedPods =
     ./defaults/io.k8s.api.batch.v1.UncountedTerminatedPods.dhall
       sha256:08cb737f27e3e25be4675d6e7d4fc3b1bb45f706d79f2130307d6c90e2bb7560

--- a/1.25/defaults/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
+++ b/1.25/defaults/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
@@ -1,4 +1,9 @@
 { onExitCodes =
     None
       ./../types/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
+, onPodConditions =
+    None
+      ( List
+          ./../types/io.k8s.api.batch.v1.PodFailurePolicyOnPodConditionsPattern.dhall
+      )
 }

--- a/1.25/package.dhall
+++ b/1.25/package.dhall
@@ -1,14 +1,14 @@
   ./schemas.dhall
-    sha256:c64e7a98bc9119195166b0ebef96eb6d9efa6dcbd47c85a1aebccfaf72a11c47
+    sha256:2580fc78bb51a99f39f526e2ef13d26a21293440a57b08fe8ab67f55475e69e2
 ∧ { IntOrString =
       ( ./types.dhall
-          sha256:b337440ff13b8a5f3946132a38cf57c576b7e43ee34d5a61785982cabc4ab4d8
+          sha256:375caa97f438849b595d758ee556265021b362b6a5beea8bdf01d7556f823880
       ).IntOrString
   , NatOrString =
       ( ./types.dhall
-          sha256:b337440ff13b8a5f3946132a38cf57c576b7e43ee34d5a61785982cabc4ab4d8
+          sha256:375caa97f438849b595d758ee556265021b362b6a5beea8bdf01d7556f823880
       ).NatOrString
   , Resource =
       ./typesUnion.dhall
-        sha256:762fa7857b7150a22c0ff13fbe19adcf00460e9ad2f468c183577d744a90908e
+        sha256:2c426e35c6e961e5f1878c8a2c0953de587db330b8e5876eb41e940da8e9d691
   }

--- a/1.25/schemas.dhall
+++ b/1.25/schemas.dhall
@@ -191,110 +191,110 @@
     ./schemas/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:e18f9c9a292543e64df19c0de89e8f25c726d3cba0a90d2d21af7594312362b1
 , ContainerResourceMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:36ff1bee1c3459f052794978a1273fa93651577fe16cbc1bf9487f0b2ddba0c7
 , ContainerResourceMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:3eefa7925d8eba0567f5d5568fa315976e35160d4ab6f3623eb6dd85f9ccddaf
 , CrossVersionObjectReference =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:61ee2b43f8d51e3222dc6d83316419779f3a36b98042ae712460a19cd86a2347
 , ExternalMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:2f0cec3e2fffe0fea5844aee4958f2b7091deddd3b634cd964f5cdb2244bc94d
 , ExternalMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:26c313df8a9fa25c943f326eefd4d49d781261e9c649543cf238533297c1a310
 , HPAScalingPolicy =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:acde7200c0df249cd86bdbe36d4c064027b247e90c9865e3005792a7a19bdf72
 , HPAScalingRules =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:e45bf4e3d80958bab5ab6e79b3dfc3ba49c2e30d5a23c955dcf5b872058cfd22
 , HorizontalPodAutoscaler =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:f514924b3f46640b63d499844e8c12258cb9231ee845878e144399e7bff91e53
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:34bb4237fb79fb9f2c03eb7279089707bda4e065190b7d395fb7cf00acd90110
 , HorizontalPodAutoscalerBehavior =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:6f774597465dd56c7dad19120e1a9bd5c1ade02f4873b63a680a8aaea7eef85b
 , HorizontalPodAutoscalerCondition =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
 , HorizontalPodAutoscalerList =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:48089b8e7b6712b0105466db29c1b64dc8db247939251c56b741b945e80fc6d4
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:09baddf41bd708de939e29474ea0f92310afbd6cfa95660ee4224fbfb7ee297f
 , HorizontalPodAutoscalerSpec =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:65a8cf241c397235a0d8d9523a54edc00f18ee65f853f1b0c5089bc7211e6f5e
 , HorizontalPodAutoscalerStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:bd66c21adea02eec8de311f03ce19ebad46f1f5cf04e9c513826b4f0baa4058e
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:45a7b51f19d52edc9f4668c2b39f216fde647354a05ba9c06515439408a9a61b
 , MetricIdentifier =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:bea4e0cd6bbe33da199a60ba9e64a127f2efade2f28d2ad21195ee352dd82f6f
 , MetricSpec =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:14d8364ea2a65676a8047a552bc2dfd20c1442478502cebdece7ae6198ea03e2
 , MetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:2696496da6abf3ac323f6495e91caa9741fe2cad43599371a3926d3d3c1694a9
 , MetricTarget =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:59aa69e80c7c4f0efc048a98fd1f5bd3b1fd7f2ab430ef2bd3437ded47cfe697
 , MetricValueStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:9f227712e34f51bf0cd1c70f826a62d9d890c506aec443ffd9438a27c154c8d6
 , ObjectMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:350b8d92a2af651d36a2965596a17ca8e0b106c1ed488a88416b12dbb9f9fd13
 , ObjectMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:1577255093301f34275a36912b13a5447409b5f15766b02d7e6c447e49bc3af5
 , PodsMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:2f0cec3e2fffe0fea5844aee4958f2b7091deddd3b634cd964f5cdb2244bc94d
 , PodsMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:26c313df8a9fa25c943f326eefd4d49d781261e9c649543cf238533297c1a310
 , ResourceMetricSource =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:2541c66165e60d23503f846acb31dd67b371114819be19bc006df4369c9da13d
 , ResourceMetricStatus =
-    ./schemas/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./schemas/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , CronJob =
     ./schemas/io.k8s.api.batch.v1.CronJob.dhall
-      sha256:6b4a2638bb2c8e069d6a7cb8673c6a3e85b05117952ce99c463090d9fa91f190
+      sha256:4faa1512080301a6058d211bf07bef0f252fa826112fa72c5c17453f8616ec82
 , CronJobList =
     ./schemas/io.k8s.api.batch.v1.CronJobList.dhall
-      sha256:29be0686929c151828b865fae6eb621c0d5f5dd6e505a717b7edac20aad0cd08
+      sha256:69fc8c1014dc2ecde1a0b9620ebb40fc86d84c31be5b31d507edc42e2131754a
 , CronJobSpec =
     ./schemas/io.k8s.api.batch.v1.CronJobSpec.dhall
-      sha256:f80e525a92fd384b71d2fa54ba2b9be75d4e48db5cd1565661a373c7dcdcf104
+      sha256:86adb05571cf5c53cb2dedc904d5e36c537220ccfd05f2aa99e1d2ad03dc4392
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1.CronJobStatus.dhall
       sha256:4195609284453e05a1a48fddba4f983408f6149b8a63b77c7ee0b873ff132fa3
 , Job =
     ./schemas/io.k8s.api.batch.v1.Job.dhall
-      sha256:2d869cd747c49b9a88b24913b1474f140c94cf5433189bd9bb52f26dcd7a9ddd
+      sha256:cd7b42fea9234cc30e404363209eaf6cc866c24c406b01df75cbb84310c296d8
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall
       sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
     ./schemas/io.k8s.api.batch.v1.JobList.dhall
-      sha256:8a28a73e35a37e335121c1f1141c759f47c0ffe114178befd3829c4e274c8a33
+      sha256:2032af37f035d43a9a3ef704a82afc70abdf85ae496f85ed81960f2a2696e2e7
 , JobSpec =
     ./schemas/io.k8s.api.batch.v1.JobSpec.dhall
-      sha256:c9d7d502322e2a881c785511b3f54783040401520abbdee235cb910de3034167
+      sha256:14cb74434559c0433474021aa3d0ca673f432277e8b3cc6628eddb4060592ab6
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall
       sha256:9cfa484f31ae2f325a3d0914ec4a463acf6b8cc497dc4306e82767ae62085581
 , JobTemplateSpec =
     ./schemas/io.k8s.api.batch.v1.JobTemplateSpec.dhall
-      sha256:226c70bbd2a4e9efaf373cb2bdac63d77072fafb11e799b41fc054094b54e0e8
+      sha256:b42b84399da805fd257260fcc39feece6dd9433d3a907afc2e2147287f94308b
 , PodFailurePolicy =
     ./schemas/io.k8s.api.batch.v1.PodFailurePolicy.dhall
-      sha256:96d61b711075ff84e4a7a77fa683d1b5a6e9c33b7ad8401120432432e4139335
+      sha256:a4feab0d7e341a04e7b2b5a1b01ed130f53e645bebd7ae68eefa02d30ffa38cc
 , PodFailurePolicyOnExitCodesRequirement =
     ./schemas/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
       sha256:e6318b980825bb5316107a1c51b24106a796b2e9251b7f477c6ab59050560cf2
@@ -303,7 +303,7 @@
       sha256:e4149e032b400080a30b8128b6ae7debc9b9f72d29b9dfa46864ba8f95b1f5da
 , PodFailurePolicyRule =
     ./schemas/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
-      sha256:116029a86eaa7d61a246bb8626662b7cefda687f98126142a955d3711a2b3b11
+      sha256:9d9e14f6e475038f42c481ad4db711dcea46d2ddd45e7f0227660a11d2f783eb
 , UncountedTerminatedPods =
     ./schemas/io.k8s.api.batch.v1.UncountedTerminatedPods.dhall
       sha256:9ae141e1311798cf9a4ea3069462d2d61e4effc989cbe9503f99056913af4c77

--- a/1.25/types.dhall
+++ b/1.25/types.dhall
@@ -194,110 +194,110 @@
     ./types/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:d76d78afa568044a4282306ada81504a5d800bc79be897cef1d388fc40903cdb
 , ContainerResourceMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:d761dd52e0d1d11ab9ffb28979fa2ff7e01051b1b08ab3624810e7048a653686
 , ContainerResourceMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:767b644ff3d3493573fa7fb4337b766a9e8fcb092b70c03e29424110615ec7bd
 , CrossVersionObjectReference =
-    ./types/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./types/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
 , ExternalMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 , ExternalMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 , HPAScalingPolicy =
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:5792aa8931dc20e3fbb0fbc7b90ac64b3d6699c27d80177168188426c6e4b2b0
 , HPAScalingRules =
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:83f98e95649ea8cc44556dba95e71ef6e9ffee78a5ed0de47d652ed81661905a
 , HorizontalPodAutoscaler =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:8ae199939af07d554a3ea1bd669745e8a3f9e021bbb95af1dca11830846a6ba7
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:f633a822d5c6cd3f0dd10157176ccd028591abc1dc745ef8a6457a2d9a030624
 , HorizontalPodAutoscalerBehavior =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:78306e919b5a909c2c4bf5724963f36aea3fc948fd41be8fe4404963bd424e9c
 , HorizontalPodAutoscalerCondition =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 , HorizontalPodAutoscalerList =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:8163f4d8782b2bb2009cb885c814048acc175c77274f9d625a99cb15ae9475a6
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:f06021ab4456f962962be04240b79c49096e5c5e9d8de70b340a7848d4828716
 , HorizontalPodAutoscalerSpec =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:b0e129dc0cb6ea27cb54b6e96f2aa0dfdff0914b03cfa7758c8f218552b45386
 , HorizontalPodAutoscalerStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:675d444e0ddc06a7bf0b3b4d4d28394d0c6ac670a7331ac51848896ff571fe82
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:a8c411695d82de0e89f9dc66a256e075410629a2caf6a39314d31a45581a2f84
 , MetricIdentifier =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:741008bebbc428229112067a8b8ce6e2e14999cd879329648d9de3b46a24323f
 , MetricSpec =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:6cba72b61855a81623f01466169a6ded6f89d5b838b1644991daac284bb0e536
 , MetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:18b773c6aed1cb379b13b9425d8b56bfd881a6e167f77de96ebc3742fa30578a
 , MetricTarget =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:d4d74e0604de0d8f2f8aaca8effd873d84d2c1713b2715a6fbac77f3c77121f5
 , MetricValueStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:727bb14d4e87444e89ddba893b699c36600c6758ba0546ea468a61c4a2791d59
 , ObjectMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:5b41279b44559ad98a1b79c3d5c5c7a9b5056f80ac44ab84f5dae89f35a5f1d6
 , ObjectMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9cc9ccb303bee6e50625a232ed6e385e23c9055ef7ab6449dc66313014bd6e53
 , PodsMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 , PodsMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 , ResourceMetricSource =
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9348a553be2edd12c07b60261e671d694617b2288451f8644b09f003ccc2c47b
 , ResourceMetricStatus =
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , CronJob =
     ./types/io.k8s.api.batch.v1.CronJob.dhall
-      sha256:e1b1fad6d1aa53634c0f159e4e7ed07d9c2a43b2ad65dcf0b95b310a2072c9bd
+      sha256:3fdcf8c9dd48c70824e2b5f02c18b8156acedefe1a30aa4dc05da99313e6f5c2
 , CronJobList =
     ./types/io.k8s.api.batch.v1.CronJobList.dhall
-      sha256:ce93bf0b3f3bfb95b103d934a37dbf7709838872ca1c92f16e6b98ca8983932f
+      sha256:e681f6d0a640f90c129719b71780578a62e1e7ef53073fc289f8b4b00205565b
 , CronJobSpec =
     ./types/io.k8s.api.batch.v1.CronJobSpec.dhall
-      sha256:79bd2848bd20a9f003103bbd517f093d39d87892c4f17cd505ad0a6d1a92e4bb
+      sha256:894f62e9cc1cba83b4c9559957d1491f6624be60c2d5811dcc065f9c1fe67ce7
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1.CronJobStatus.dhall
       sha256:9b8e3c84d094e905de2f0b1a35ddbb36e155fd91cf8881ef2053a118f9de563e
 , Job =
     ./types/io.k8s.api.batch.v1.Job.dhall
-      sha256:585aa093b7a7b6969c263052546cd1f13f05c52dc3b0d5a4e34373e630c89b11
+      sha256:ed7f2688a7c2c1b5b3f083e1457963d0f70c0d8d95cdf5d4ebf6644df7f35e1f
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall
       sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
     ./types/io.k8s.api.batch.v1.JobList.dhall
-      sha256:205fee232d295925c631660d56ecbbe0acf429072a1e134ad417216ebb255a6c
+      sha256:2a73b4c4b685196af13bd1a3455c382305084a2852bb80dbe3ad9ab540abec24
 , JobSpec =
     ./types/io.k8s.api.batch.v1.JobSpec.dhall
-      sha256:0270f0f6747c9aeeac3948b5f55e7ababc022b40bf06c0e9396230a4b66b8e35
+      sha256:daff98fab93c447d2ba10152306a0a5da9d4e69b45214be957be1aa9256ae7e4
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall
       sha256:e4e81d8eeb147604f14e8e3e0e1cb40aa664ab38597e37fea05a75257c990493
 , JobTemplateSpec =
     ./types/io.k8s.api.batch.v1.JobTemplateSpec.dhall
-      sha256:0e4f5eff4a1e59f33da173508ea198883a5a9bce6117ee6932826f20a4ea3c2d
+      sha256:f48885341128a82329dc6d990e35b2ccbba29e789e1e02ff1b9497c21bf20f14
 , PodFailurePolicy =
     ./types/io.k8s.api.batch.v1.PodFailurePolicy.dhall
-      sha256:06e1c2d41091cd26c69fcdc435c7a536114329fa52d97bf7d6cedca449df5fa2
+      sha256:6c580418eb0faa2f0687c1594155ac9eb47a0e6dfec02d07395b85c84a02d2ed
 , PodFailurePolicyOnExitCodesRequirement =
     ./types/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
       sha256:d4a392b0b061905e6fc0af2308194edda6e41292a38b78516b04f2a656a55268
@@ -306,7 +306,7 @@
       sha256:43b53130399326f040043a4d653487a35df9c35342e94f97ece4dc13e66667cf
 , PodFailurePolicyRule =
     ./types/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
-      sha256:70e2c37a714711506e1abb32a0a4d49d89998ae0f66bd59fc4b62b64faad421c
+      sha256:e72ba8e8401635ead7a9cd4847f034500493c1dec35f1e0ccad2998c336cade8
 , UncountedTerminatedPods =
     ./types/io.k8s.api.batch.v1.UncountedTerminatedPods.dhall
       sha256:3912761a94b260f7643ce02f72fa247a79d9a2c6a575749cc43641eb2d8ef764

--- a/1.25/types/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
+++ b/1.25/types/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
@@ -1,6 +1,7 @@
 { action : Text
-, onPodConditions :
-    List ./io.k8s.api.batch.v1.PodFailurePolicyOnPodConditionsPattern.dhall
 , onExitCodes :
     Optional ./io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
+, onPodConditions :
+    Optional
+      (List ./io.k8s.api.batch.v1.PodFailurePolicyOnPodConditionsPattern.dhall)
 }

--- a/1.25/typesUnion.dhall
+++ b/1.25/typesUnion.dhall
@@ -194,110 +194,110 @@
     ./types/io.k8s.api.autoscaling.v1.ScaleStatus.dhall
       sha256:d76d78afa568044a4282306ada81504a5d800bc79be897cef1d388fc40903cdb
 | ContainerResourceMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource.dhall
       sha256:d761dd52e0d1d11ab9ffb28979fa2ff7e01051b1b08ab3624810e7048a653686
 | ContainerResourceMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:767b644ff3d3493573fa7fb4337b766a9e8fcb092b70c03e29424110615ec7bd
 | CrossVersionObjectReference :
-    ./types/io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference.dhall
+    ./types/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
       sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
 | ExternalMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 | ExternalMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ExternalMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 | HPAScalingPolicy :
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingPolicy.dhall
       sha256:5792aa8931dc20e3fbb0fbc7b90ac64b3d6699c27d80177168188426c6e4b2b0
 | HPAScalingRules :
-    ./types/io.k8s.api.autoscaling.v2beta2.HPAScalingRules.dhall
+    ./types/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:83f98e95649ea8cc44556dba95e71ef6e9ffee78a5ed0de47d652ed81661905a
 | HorizontalPodAutoscaler :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler.dhall
-      sha256:8ae199939af07d554a3ea1bd669745e8a3f9e021bbb95af1dca11830846a6ba7
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:f633a822d5c6cd3f0dd10157176ccd028591abc1dc745ef8a6457a2d9a030624
 | HorizontalPodAutoscalerBehavior :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:78306e919b5a909c2c4bf5724963f36aea3fc948fd41be8fe4404963bd424e9c
 | HorizontalPodAutoscalerCondition :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
 | HorizontalPodAutoscalerList :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList.dhall
-      sha256:8163f4d8782b2bb2009cb885c814048acc175c77274f9d625a99cb15ae9475a6
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:f06021ab4456f962962be04240b79c49096e5c5e9d8de70b340a7848d4828716
 | HorizontalPodAutoscalerSpec :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
       sha256:b0e129dc0cb6ea27cb54b6e96f2aa0dfdff0914b03cfa7758c8f218552b45386
 | HorizontalPodAutoscalerStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus.dhall
-      sha256:675d444e0ddc06a7bf0b3b4d4d28394d0c6ac670a7331ac51848896ff571fe82
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:a8c411695d82de0e89f9dc66a256e075410629a2caf6a39314d31a45581a2f84
 | MetricIdentifier :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricIdentifier.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:741008bebbc428229112067a8b8ce6e2e14999cd879329648d9de3b46a24323f
 | MetricSpec :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricSpec.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricSpec.dhall
       sha256:6cba72b61855a81623f01466169a6ded6f89d5b838b1644991daac284bb0e536
 | MetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricStatus.dhall
       sha256:18b773c6aed1cb379b13b9425d8b56bfd881a6e167f77de96ebc3742fa30578a
 | MetricTarget :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricTarget.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricTarget.dhall
       sha256:d4d74e0604de0d8f2f8aaca8effd873d84d2c1713b2715a6fbac77f3c77121f5
 | MetricValueStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.MetricValueStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.MetricValueStatus.dhall
       sha256:727bb14d4e87444e89ddba893b699c36600c6758ba0546ea468a61c4a2791d59
 | ObjectMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricSource.dhall
       sha256:5b41279b44559ad98a1b79c3d5c5c7a9b5056f80ac44ab84f5dae89f35a5f1d6
 | ObjectMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ObjectMetricStatus.dhall
       sha256:9cc9ccb303bee6e50625a232ed6e385e23c9055ef7ab6449dc66313014bd6e53
 | PodsMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
 | PodsMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.PodsMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.PodsMetricStatus.dhall
       sha256:5d11c23db9ca057f4bb098633f9e6c4653dec870dc3657ad1b8ef0aee2d4cc68
 | ResourceMetricSource :
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricSource.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricSource.dhall
       sha256:9348a553be2edd12c07b60261e671d694617b2288451f8644b09f003ccc2c47b
 | ResourceMetricStatus :
-    ./types/io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus.dhall
+    ./types/io.k8s.api.autoscaling.v2.ResourceMetricStatus.dhall
       sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | CronJob :
     ./types/io.k8s.api.batch.v1.CronJob.dhall
-      sha256:e1b1fad6d1aa53634c0f159e4e7ed07d9c2a43b2ad65dcf0b95b310a2072c9bd
+      sha256:3fdcf8c9dd48c70824e2b5f02c18b8156acedefe1a30aa4dc05da99313e6f5c2
 | CronJobList :
     ./types/io.k8s.api.batch.v1.CronJobList.dhall
-      sha256:ce93bf0b3f3bfb95b103d934a37dbf7709838872ca1c92f16e6b98ca8983932f
+      sha256:e681f6d0a640f90c129719b71780578a62e1e7ef53073fc289f8b4b00205565b
 | CronJobSpec :
     ./types/io.k8s.api.batch.v1.CronJobSpec.dhall
-      sha256:79bd2848bd20a9f003103bbd517f093d39d87892c4f17cd505ad0a6d1a92e4bb
+      sha256:894f62e9cc1cba83b4c9559957d1491f6624be60c2d5811dcc065f9c1fe67ce7
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1.CronJobStatus.dhall
       sha256:9b8e3c84d094e905de2f0b1a35ddbb36e155fd91cf8881ef2053a118f9de563e
 | Job :
     ./types/io.k8s.api.batch.v1.Job.dhall
-      sha256:585aa093b7a7b6969c263052546cd1f13f05c52dc3b0d5a4e34373e630c89b11
+      sha256:ed7f2688a7c2c1b5b3f083e1457963d0f70c0d8d95cdf5d4ebf6644df7f35e1f
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall
       sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
     ./types/io.k8s.api.batch.v1.JobList.dhall
-      sha256:205fee232d295925c631660d56ecbbe0acf429072a1e134ad417216ebb255a6c
+      sha256:2a73b4c4b685196af13bd1a3455c382305084a2852bb80dbe3ad9ab540abec24
 | JobSpec :
     ./types/io.k8s.api.batch.v1.JobSpec.dhall
-      sha256:0270f0f6747c9aeeac3948b5f55e7ababc022b40bf06c0e9396230a4b66b8e35
+      sha256:daff98fab93c447d2ba10152306a0a5da9d4e69b45214be957be1aa9256ae7e4
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall
       sha256:e4e81d8eeb147604f14e8e3e0e1cb40aa664ab38597e37fea05a75257c990493
 | JobTemplateSpec :
     ./types/io.k8s.api.batch.v1.JobTemplateSpec.dhall
-      sha256:0e4f5eff4a1e59f33da173508ea198883a5a9bce6117ee6932826f20a4ea3c2d
+      sha256:f48885341128a82329dc6d990e35b2ccbba29e789e1e02ff1b9497c21bf20f14
 | PodFailurePolicy :
     ./types/io.k8s.api.batch.v1.PodFailurePolicy.dhall
-      sha256:06e1c2d41091cd26c69fcdc435c7a536114329fa52d97bf7d6cedca449df5fa2
+      sha256:6c580418eb0faa2f0687c1594155ac9eb47a0e6dfec02d07395b85c84a02d2ed
 | PodFailurePolicyOnExitCodesRequirement :
     ./types/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
       sha256:d4a392b0b061905e6fc0af2308194edda6e41292a38b78516b04f2a656a55268
@@ -306,7 +306,7 @@
       sha256:43b53130399326f040043a4d653487a35df9c35342e94f97ece4dc13e66667cf
 | PodFailurePolicyRule :
     ./types/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
-      sha256:70e2c37a714711506e1abb32a0a4d49d89998ae0f66bd59fc4b62b64faad421c
+      sha256:e72ba8e8401635ead7a9cd4847f034500493c1dec35f1e0ccad2998c336cade8
 | UncountedTerminatedPods :
     ./types/io.k8s.api.batch.v1.UncountedTerminatedPods.dhall
       sha256:3912761a94b260f7643ce02f72fa247a79d9a2c6a575749cc43641eb2d8ef764

--- a/1.26/defaults.dhall
+++ b/1.26/defaults.dhall
@@ -223,21 +223,6 @@
 , SubjectRulesReviewStatus =
     ./defaults/io.k8s.api.authorization.v1.SubjectRulesReviewStatus.dhall
       sha256:600e352e2ef95e8727131ab6f365319b62e001cb4b6962429d6f5f06777efb95
-, CrossVersionObjectReference =
-    ./defaults/io.k8s.api.autoscaling.v1.CrossVersionObjectReference.dhall
-      sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
-, HorizontalPodAutoscaler =
-    ./defaults/io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler.dhall
-      sha256:4f1b5ceca5a4832aa0e7d737f2f7a4403f638d482063a12d6de0778fa4f05626
-, HorizontalPodAutoscalerList =
-    ./defaults/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList.dhall
-      sha256:4b1ce10f8beb3d1ed9e65647dac62c15d7a84bb51ba0469b4260f03e41a610b7
-, HorizontalPodAutoscalerSpec =
-    ./defaults/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec.dhall
-      sha256:89c6c12ee1db1f38c599f133873e91a7988b089d1a6c1521fddeed91526b919e
-, HorizontalPodAutoscalerStatus =
-    ./defaults/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus.dhall
-      sha256:323797f9c67ef3e9c5fde42347abcdf8a55fa9e7de0b62e1d141ce1e9fe21995
 , Scale =
     ./defaults/io.k8s.api.autoscaling.v1.Scale.dhall
       sha256:195ae5274aca847c22ce08efd6cfe224ac90282bdfa7fa635bf7c7a750180b08
@@ -253,6 +238,9 @@
 , ContainerResourceMetricStatus =
     ./defaults/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
+, CrossVersionObjectReference =
+    ./defaults/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
+      sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , ExternalMetricSource =
     ./defaults/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
@@ -265,12 +253,24 @@
 , HPAScalingRules =
     ./defaults/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:2df1d7fbfb879b193f09e8045d0bb7931fd1dccbf8bceef55a1bf17f69328f98
+, HorizontalPodAutoscaler =
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:4c43505a237707cd5a115fd7a0e02bd991b03e21fbd520ecd80dddce19a3e3ad
 , HorizontalPodAutoscalerBehavior =
     ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:33a2d384b965bae8dbd1f5c746a075a1ac7c3c855cf65efb31fe392b86deb626
 , HorizontalPodAutoscalerCondition =
     ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:fef63958bc998f900417bd68974df7936535249af83edf1183721637fa3e7257
+, HorizontalPodAutoscalerList =
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:e73002ff3362f3ad753a59819546e516789338cd5ecd971037762679150658ad
+, HorizontalPodAutoscalerSpec =
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
+      sha256:2dfea72d3ad77df1d052736afa7c73d9c3b8186f9afa4a81972ea790a05e8b7d
+, HorizontalPodAutoscalerStatus =
+    ./defaults/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:7033a28e2dc666d82fe56df0739fcbdc5c1df5fb4954e01df8c7684d2d0268fe
 , MetricIdentifier =
     ./defaults/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:ff0e0e9c4fcd3a099f08ac65793ca1ca6152467acd72c3709d4227a4621f60f9
@@ -306,7 +306,7 @@
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , CronJob =
     ./defaults/io.k8s.api.batch.v1.CronJob.dhall
-      sha256:71136c555eb53f04e1a6d338273b143fa9197fc1836b149ec07105f01346de22
+      sha256:a6865ef3aec69a40f315479403c11425722dd976ada54cff323498090553bfda
 , CronJobList =
     ./defaults/io.k8s.api.batch.v1.CronJobList.dhall
       sha256:d6fd6fd3d7ad351457cae2cb6e2375ac23a9c580777a1a210f6869763eaa2f6a
@@ -318,7 +318,7 @@
       sha256:c68ed687b5580fef3778bc5c18c86f5f9665b0994b7042e4ea12630c29bc3fd7
 , Job =
     ./defaults/io.k8s.api.batch.v1.Job.dhall
-      sha256:74b31c56ece92d4c8afbc50d23e4af5561181148c2524be7df97c1df320d8518
+      sha256:a08aa4ab5907bc885c920ae1d5cd391bdabe39dd2da8944b6263d5b529d3d9ab
 , JobCondition =
     ./defaults/io.k8s.api.batch.v1.JobCondition.dhall
       sha256:d7a55966e74169d85d6a02388fd65f2759da9f8005cc0be8bee6bed7398af0eb
@@ -327,13 +327,13 @@
       sha256:75e1f5c7bee0245bb1592e892cc2fe4382273df957058f6e43514c8df0d3dea8
 , JobSpec =
     ./defaults/io.k8s.api.batch.v1.JobSpec.dhall
-      sha256:00980880766598075ae2fab500ddc8e14d92018c2fafea3cd9023ebd3ecf71dc
+      sha256:1a1044d7906f54eb07c5ec9472639c0eeb2a35019d375999c7221fa9063cf00c
 , JobStatus =
     ./defaults/io.k8s.api.batch.v1.JobStatus.dhall
       sha256:7448977b44a145530865d0947624165be35fc1a6fc7d2ca7e7d07346ca85f5b2
 , JobTemplateSpec =
     ./defaults/io.k8s.api.batch.v1.JobTemplateSpec.dhall
-      sha256:2a6af13c438acb9d352cd6b57784c747584606710c48843884dbc1cb27057852
+      sha256:3f7c3c6530c2d62d1b8327784f3f58174510b83dc24cc60cf11f61b2ce841b42
 , PodFailurePolicy =
     ./defaults/io.k8s.api.batch.v1.PodFailurePolicy.dhall
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
@@ -345,7 +345,7 @@
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , PodFailurePolicyRule =
     ./defaults/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
-      sha256:8dcb381b90ebfa90282ac50cf5519cf11baf89d56c173664096f889b556b5d50
+      sha256:cbd31096945c7ec703c6b10728c33533c631d6ee4b84a9bc47f641e3ee1ca9cf
 , UncountedTerminatedPods =
     ./defaults/io.k8s.api.batch.v1.UncountedTerminatedPods.dhall
       sha256:08cb737f27e3e25be4675d6e7d4fc3b1bb45f706d79f2130307d6c90e2bb7560

--- a/1.26/defaults/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
+++ b/1.26/defaults/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
@@ -1,4 +1,9 @@
 { onExitCodes =
     None
       ./../types/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
+, onPodConditions =
+    None
+      ( List
+          ./../types/io.k8s.api.batch.v1.PodFailurePolicyOnPodConditionsPattern.dhall
+      )
 }

--- a/1.26/package.dhall
+++ b/1.26/package.dhall
@@ -1,14 +1,14 @@
   ./schemas.dhall
-    sha256:af57046545457a0436e7456cc7673c7c7e0257ebb7aeb0573e89ec85fca6c385
+    sha256:c5127763929e0fa0429ea91b8d525ef32f9bd760cf6a93f02d36fc621e5f24e0
 ∧ { IntOrString =
       ( ./types.dhall
-          sha256:e2d972b6cbae78100a146c69daecacf0a96a6cd623b0380aa8fc03e48e2c74a3
+          sha256:9e933e134e6644463389fbac57fbf35e8ea3e3fcd4d10568d3738b32b2450324
       ).IntOrString
   , NatOrString =
       ( ./types.dhall
-          sha256:e2d972b6cbae78100a146c69daecacf0a96a6cd623b0380aa8fc03e48e2c74a3
+          sha256:9e933e134e6644463389fbac57fbf35e8ea3e3fcd4d10568d3738b32b2450324
       ).NatOrString
   , Resource =
       ./typesUnion.dhall
-        sha256:b53f872d88e240d1dc5bcf0eaf4c745876fd4cfccbe31220a9e5fa63bc7a8cb0
+        sha256:e5d3160b6138a20d623f35cbceb714250b28373b5b8d5ea07f62d15636ee6421
   }

--- a/1.26/schemas.dhall
+++ b/1.26/schemas.dhall
@@ -223,21 +223,6 @@
 , SubjectRulesReviewStatus =
     ./schemas/io.k8s.api.authorization.v1.SubjectRulesReviewStatus.dhall
       sha256:7a3e75e091018c08a11fc0664e50f025ed09d142fd694b67a24e23a738375bfe
-, CrossVersionObjectReference =
-    ./schemas/io.k8s.api.autoscaling.v1.CrossVersionObjectReference.dhall
-      sha256:61ee2b43f8d51e3222dc6d83316419779f3a36b98042ae712460a19cd86a2347
-, HorizontalPodAutoscaler =
-    ./schemas/io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler.dhall
-      sha256:788f8b4e65c08b123a58985094d0ebee51fb1957a6bec025af8422230d80b4cf
-, HorizontalPodAutoscalerList =
-    ./schemas/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList.dhall
-      sha256:5f8bf2329b2461b7515832977064796c072134cddca08af2f7d1cee5845fa691
-, HorizontalPodAutoscalerSpec =
-    ./schemas/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec.dhall
-      sha256:0be6a8a14bbc2d41dab4a774d3478c3626f4cf116bfef6ddd18ff185a77eaf9b
-, HorizontalPodAutoscalerStatus =
-    ./schemas/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus.dhall
-      sha256:bb91e3fc2c8a8f2dd8e4420d5171d62b7ac92629c6b92348e7e01424c862f515
 , Scale =
     ./schemas/io.k8s.api.autoscaling.v1.Scale.dhall
       sha256:4d6429271ee789f9f946438fac7602109ba60e596b2c7c03c6a2eb68c7d09118
@@ -253,6 +238,9 @@
 , ContainerResourceMetricStatus =
     ./schemas/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:3eefa7925d8eba0567f5d5568fa315976e35160d4ab6f3623eb6dd85f9ccddaf
+, CrossVersionObjectReference =
+    ./schemas/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
+      sha256:61ee2b43f8d51e3222dc6d83316419779f3a36b98042ae712460a19cd86a2347
 , ExternalMetricSource =
     ./schemas/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:2f0cec3e2fffe0fea5844aee4958f2b7091deddd3b634cd964f5cdb2244bc94d
@@ -265,12 +253,24 @@
 , HPAScalingRules =
     ./schemas/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:e45bf4e3d80958bab5ab6e79b3dfc3ba49c2e30d5a23c955dcf5b872058cfd22
+, HorizontalPodAutoscaler =
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:34bb4237fb79fb9f2c03eb7279089707bda4e065190b7d395fb7cf00acd90110
 , HorizontalPodAutoscalerBehavior =
     ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:6f774597465dd56c7dad19120e1a9bd5c1ade02f4873b63a680a8aaea7eef85b
 , HorizontalPodAutoscalerCondition =
     ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:47ec59edf7c6f9429301ee78bfdfc84bbfdbf494fe3b461db05ae03de8c6817d
+, HorizontalPodAutoscalerList =
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:09baddf41bd708de939e29474ea0f92310afbd6cfa95660ee4224fbfb7ee297f
+, HorizontalPodAutoscalerSpec =
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
+      sha256:65a8cf241c397235a0d8d9523a54edc00f18ee65f853f1b0c5089bc7211e6f5e
+, HorizontalPodAutoscalerStatus =
+    ./schemas/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:45a7b51f19d52edc9f4668c2b39f216fde647354a05ba9c06515439408a9a61b
 , MetricIdentifier =
     ./schemas/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:bea4e0cd6bbe33da199a60ba9e64a127f2efade2f28d2ad21195ee352dd82f6f
@@ -306,37 +306,37 @@
       sha256:81ce7774216beab19eea655bbf4409a5578fc01c8c63982cc87fb885b90a8d9b
 , CronJob =
     ./schemas/io.k8s.api.batch.v1.CronJob.dhall
-      sha256:d020da85cb35bdb6d36c7e9ff71216c7334696b7a848eba9aa25559c7635ffae
+      sha256:bedc1eaefec064077ca160c5763d627907550bff18178462ccca34d11a251b58
 , CronJobList =
     ./schemas/io.k8s.api.batch.v1.CronJobList.dhall
-      sha256:6e535dd0216935a2a2dd8c65d23a00460eef323a63fb16521ed6fa2952b183e4
+      sha256:b50c0c374c7a68a7be7468a6297afb9d1b97f0d6d699780dc66c53416e02e3bd
 , CronJobSpec =
     ./schemas/io.k8s.api.batch.v1.CronJobSpec.dhall
-      sha256:42a0dbda2d4869285dd27b9895cb02836c5edd07f2696188cb8a6414f7d5658e
+      sha256:8469a16f24fad989207198803b7f7be1d1db6e222640c107399be475a54c3254
 , CronJobStatus =
     ./schemas/io.k8s.api.batch.v1.CronJobStatus.dhall
       sha256:4195609284453e05a1a48fddba4f983408f6149b8a63b77c7ee0b873ff132fa3
 , Job =
     ./schemas/io.k8s.api.batch.v1.Job.dhall
-      sha256:396c18c3ceed300b7876f21aab12b1bd99d8e62eeac6e8aa6df41320fbe3c1a2
+      sha256:0633c975797c15af5e2c8dd405958d3de6a47a54f5d86339ab9ac582f9f13eb7
 , JobCondition =
     ./schemas/io.k8s.api.batch.v1.JobCondition.dhall
       sha256:6d9583ad8e06d58d2ad644b0ed01b6514e879b734bc81a54cf029060cc3bf76d
 , JobList =
     ./schemas/io.k8s.api.batch.v1.JobList.dhall
-      sha256:7945d0310c0b21db527a5a7c3a5640b5b32d5924d595f5e1d61220beeb38d3c1
+      sha256:b44bad96249868b9687c3787f62e00466a80f6bed5db3c1f93ea607a4f3cef1a
 , JobSpec =
     ./schemas/io.k8s.api.batch.v1.JobSpec.dhall
-      sha256:422546ac8cd9b127e9a1df8ad28b5bc6c44402f9d982b2294d94fbdffad2d2bf
+      sha256:10a24ebecd02db8445431fbe34e55ceeee54c4cf66d7baf10a97eee544a6b7cf
 , JobStatus =
     ./schemas/io.k8s.api.batch.v1.JobStatus.dhall
       sha256:9cfa484f31ae2f325a3d0914ec4a463acf6b8cc497dc4306e82767ae62085581
 , JobTemplateSpec =
     ./schemas/io.k8s.api.batch.v1.JobTemplateSpec.dhall
-      sha256:46f2d54fa1e342f5164c7ae79e80fd15f2d056769a5d2b28c1f5936016ca0ecb
+      sha256:3320e4c959640ceee7c6d1f6d37eb4d18ee3dabe233c832198f9bb31157048c8
 , PodFailurePolicy =
     ./schemas/io.k8s.api.batch.v1.PodFailurePolicy.dhall
-      sha256:96d61b711075ff84e4a7a77fa683d1b5a6e9c33b7ad8401120432432e4139335
+      sha256:a4feab0d7e341a04e7b2b5a1b01ed130f53e645bebd7ae68eefa02d30ffa38cc
 , PodFailurePolicyOnExitCodesRequirement =
     ./schemas/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
       sha256:e6318b980825bb5316107a1c51b24106a796b2e9251b7f477c6ab59050560cf2
@@ -345,7 +345,7 @@
       sha256:e4149e032b400080a30b8128b6ae7debc9b9f72d29b9dfa46864ba8f95b1f5da
 , PodFailurePolicyRule =
     ./schemas/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
-      sha256:116029a86eaa7d61a246bb8626662b7cefda687f98126142a955d3711a2b3b11
+      sha256:9d9e14f6e475038f42c481ad4db711dcea46d2ddd45e7f0227660a11d2f783eb
 , UncountedTerminatedPods =
     ./schemas/io.k8s.api.batch.v1.UncountedTerminatedPods.dhall
       sha256:9ae141e1311798cf9a4ea3069462d2d61e4effc989cbe9503f99056913af4c77

--- a/1.26/types.dhall
+++ b/1.26/types.dhall
@@ -226,21 +226,6 @@
 , SubjectRulesReviewStatus =
     ./types/io.k8s.api.authorization.v1.SubjectRulesReviewStatus.dhall
       sha256:04530d2b081a1f465ba6e969b650c39d68963f5c21811588e8f12c5b89229b2f
-, CrossVersionObjectReference =
-    ./types/io.k8s.api.autoscaling.v1.CrossVersionObjectReference.dhall
-      sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
-, HorizontalPodAutoscaler =
-    ./types/io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler.dhall
-      sha256:5870adbd282575d6194a847fbad5a005789224b1452555cd90816af4c2fdf8e3
-, HorizontalPodAutoscalerList =
-    ./types/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList.dhall
-      sha256:287542f449350b2f7d7756155baa449356f203a88f240bfdd9fa8d00903aa501
-, HorizontalPodAutoscalerSpec =
-    ./types/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec.dhall
-      sha256:b4692ebca6d40939232c62f1f36ae93af89f950e86fbf643faf1064d10273db2
-, HorizontalPodAutoscalerStatus =
-    ./types/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus.dhall
-      sha256:ffdb1a0a7fb8f47a133137b49e971e2d368094b68ae60bdcb2c55b55d349e7cf
 , Scale =
     ./types/io.k8s.api.autoscaling.v1.Scale.dhall
       sha256:a6521302cb97c3170df42d823fffc975cb64c89dae3195efffc94ac039f62796
@@ -256,6 +241,9 @@
 , ContainerResourceMetricStatus =
     ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:767b644ff3d3493573fa7fb4337b766a9e8fcb092b70c03e29424110615ec7bd
+, CrossVersionObjectReference =
+    ./types/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
+      sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
 , ExternalMetricSource =
     ./types/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
@@ -268,12 +256,24 @@
 , HPAScalingRules =
     ./types/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:83f98e95649ea8cc44556dba95e71ef6e9ffee78a5ed0de47d652ed81661905a
+, HorizontalPodAutoscaler =
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:f633a822d5c6cd3f0dd10157176ccd028591abc1dc745ef8a6457a2d9a030624
 , HorizontalPodAutoscalerBehavior =
     ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:78306e919b5a909c2c4bf5724963f36aea3fc948fd41be8fe4404963bd424e9c
 , HorizontalPodAutoscalerCondition =
     ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
+, HorizontalPodAutoscalerList =
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:f06021ab4456f962962be04240b79c49096e5c5e9d8de70b340a7848d4828716
+, HorizontalPodAutoscalerSpec =
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
+      sha256:b0e129dc0cb6ea27cb54b6e96f2aa0dfdff0914b03cfa7758c8f218552b45386
+, HorizontalPodAutoscalerStatus =
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:a8c411695d82de0e89f9dc66a256e075410629a2caf6a39314d31a45581a2f84
 , MetricIdentifier =
     ./types/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:741008bebbc428229112067a8b8ce6e2e14999cd879329648d9de3b46a24323f
@@ -309,37 +309,37 @@
       sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 , CronJob =
     ./types/io.k8s.api.batch.v1.CronJob.dhall
-      sha256:4410441febb3b457ce18c7f1498a724937a9662ca259d67d425e8fb883eedc35
+      sha256:b1de8f0fb1cb71310062793846bc1c5c2ba3c651f95a85fc099d35f06510c17c
 , CronJobList =
     ./types/io.k8s.api.batch.v1.CronJobList.dhall
-      sha256:17d558838367764ec463f5a71aa619e3c5da1540887fc6fc8074764c55d7b6c3
+      sha256:852106d751cca0a558bc69e350d8649cbde7f764cb704b82795b9dc5e22d59e5
 , CronJobSpec =
     ./types/io.k8s.api.batch.v1.CronJobSpec.dhall
-      sha256:abcae1d07d8d890d0441f39068419b10bd956e7c0bd3409d370fbf2991ca21ba
+      sha256:d1f21f71fb026e4723b7a5484fd6779b6ad234e3aa1b4eb7da0942f47c7b1b93
 , CronJobStatus =
     ./types/io.k8s.api.batch.v1.CronJobStatus.dhall
       sha256:9b8e3c84d094e905de2f0b1a35ddbb36e155fd91cf8881ef2053a118f9de563e
 , Job =
     ./types/io.k8s.api.batch.v1.Job.dhall
-      sha256:ae0d9f9745daf2e036e760e75e7edc56c223200ba968e121f3f52c7ab7229571
+      sha256:3d6605217ea4c5fa47f261ff33d41923920d96027abf3fa36eb0d77a9f5ed096
 , JobCondition =
     ./types/io.k8s.api.batch.v1.JobCondition.dhall
       sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 , JobList =
     ./types/io.k8s.api.batch.v1.JobList.dhall
-      sha256:9ae4c166fb1475fdebb73870b8e5d77321419d3c6d6766eabb1b7f70bf17aa52
+      sha256:04741e0110b307500d3f839880467dfc4ef05db3b21857a99c04bac4910cef94
 , JobSpec =
     ./types/io.k8s.api.batch.v1.JobSpec.dhall
-      sha256:733150c4633a649435055e84f8ae01d150059039fc4dd3fbe1b278a21145ebd6
+      sha256:38bb48d33ad6d7caea5a060e835c1d19066010cf7efa33432133faf28d3c0ef5
 , JobStatus =
     ./types/io.k8s.api.batch.v1.JobStatus.dhall
       sha256:e4e81d8eeb147604f14e8e3e0e1cb40aa664ab38597e37fea05a75257c990493
 , JobTemplateSpec =
     ./types/io.k8s.api.batch.v1.JobTemplateSpec.dhall
-      sha256:1fcb818692353c42778046bba02c79873302107540a2eea37deb09fff29f3ce3
+      sha256:296b3e92b160828be0ced73274ccdd8ecec8e3dd81d907cf386f72afb51d37db
 , PodFailurePolicy =
     ./types/io.k8s.api.batch.v1.PodFailurePolicy.dhall
-      sha256:06e1c2d41091cd26c69fcdc435c7a536114329fa52d97bf7d6cedca449df5fa2
+      sha256:6c580418eb0faa2f0687c1594155ac9eb47a0e6dfec02d07395b85c84a02d2ed
 , PodFailurePolicyOnExitCodesRequirement =
     ./types/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
       sha256:d4a392b0b061905e6fc0af2308194edda6e41292a38b78516b04f2a656a55268
@@ -348,7 +348,7 @@
       sha256:43b53130399326f040043a4d653487a35df9c35342e94f97ece4dc13e66667cf
 , PodFailurePolicyRule =
     ./types/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
-      sha256:70e2c37a714711506e1abb32a0a4d49d89998ae0f66bd59fc4b62b64faad421c
+      sha256:e72ba8e8401635ead7a9cd4847f034500493c1dec35f1e0ccad2998c336cade8
 , UncountedTerminatedPods =
     ./types/io.k8s.api.batch.v1.UncountedTerminatedPods.dhall
       sha256:3912761a94b260f7643ce02f72fa247a79d9a2c6a575749cc43641eb2d8ef764

--- a/1.26/types/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
+++ b/1.26/types/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
@@ -1,6 +1,7 @@
 { action : Text
-, onPodConditions :
-    List ./io.k8s.api.batch.v1.PodFailurePolicyOnPodConditionsPattern.dhall
 , onExitCodes :
     Optional ./io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
+, onPodConditions :
+    Optional
+      (List ./io.k8s.api.batch.v1.PodFailurePolicyOnPodConditionsPattern.dhall)
 }

--- a/1.26/typesUnion.dhall
+++ b/1.26/typesUnion.dhall
@@ -226,21 +226,6 @@
 | SubjectRulesReviewStatus :
     ./types/io.k8s.api.authorization.v1.SubjectRulesReviewStatus.dhall
       sha256:04530d2b081a1f465ba6e969b650c39d68963f5c21811588e8f12c5b89229b2f
-| CrossVersionObjectReference :
-    ./types/io.k8s.api.autoscaling.v1.CrossVersionObjectReference.dhall
-      sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
-| HorizontalPodAutoscaler :
-    ./types/io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler.dhall
-      sha256:5870adbd282575d6194a847fbad5a005789224b1452555cd90816af4c2fdf8e3
-| HorizontalPodAutoscalerList :
-    ./types/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList.dhall
-      sha256:287542f449350b2f7d7756155baa449356f203a88f240bfdd9fa8d00903aa501
-| HorizontalPodAutoscalerSpec :
-    ./types/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec.dhall
-      sha256:b4692ebca6d40939232c62f1f36ae93af89f950e86fbf643faf1064d10273db2
-| HorizontalPodAutoscalerStatus :
-    ./types/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus.dhall
-      sha256:ffdb1a0a7fb8f47a133137b49e971e2d368094b68ae60bdcb2c55b55d349e7cf
 | Scale :
     ./types/io.k8s.api.autoscaling.v1.Scale.dhall
       sha256:a6521302cb97c3170df42d823fffc975cb64c89dae3195efffc94ac039f62796
@@ -256,6 +241,9 @@
 | ContainerResourceMetricStatus :
     ./types/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus.dhall
       sha256:767b644ff3d3493573fa7fb4337b766a9e8fcb092b70c03e29424110615ec7bd
+| CrossVersionObjectReference :
+    ./types/io.k8s.api.autoscaling.v2.CrossVersionObjectReference.dhall
+      sha256:686a8f9a56cb0e403746b5c80b3e8238f51e16138f95e7fd8c3a59f75912fb2d
 | ExternalMetricSource :
     ./types/io.k8s.api.autoscaling.v2.ExternalMetricSource.dhall
       sha256:558b1d019bb7684640820a97bc0140534705a099ae6773d15cb6c459458b411d
@@ -268,12 +256,24 @@
 | HPAScalingRules :
     ./types/io.k8s.api.autoscaling.v2.HPAScalingRules.dhall
       sha256:83f98e95649ea8cc44556dba95e71ef6e9ffee78a5ed0de47d652ed81661905a
+| HorizontalPodAutoscaler :
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler.dhall
+      sha256:f633a822d5c6cd3f0dd10157176ccd028591abc1dc745ef8a6457a2d9a030624
 | HorizontalPodAutoscalerBehavior :
     ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior.dhall
       sha256:78306e919b5a909c2c4bf5724963f36aea3fc948fd41be8fe4404963bd424e9c
 | HorizontalPodAutoscalerCondition :
     ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition.dhall
       sha256:10de5e5aed3f6e1721f79bd8e2f9ffcecb92658fbe7442e6eaf74c6780b4779d
+| HorizontalPodAutoscalerList :
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList.dhall
+      sha256:f06021ab4456f962962be04240b79c49096e5c5e9d8de70b340a7848d4828716
+| HorizontalPodAutoscalerSpec :
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec.dhall
+      sha256:b0e129dc0cb6ea27cb54b6e96f2aa0dfdff0914b03cfa7758c8f218552b45386
+| HorizontalPodAutoscalerStatus :
+    ./types/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus.dhall
+      sha256:a8c411695d82de0e89f9dc66a256e075410629a2caf6a39314d31a45581a2f84
 | MetricIdentifier :
     ./types/io.k8s.api.autoscaling.v2.MetricIdentifier.dhall
       sha256:741008bebbc428229112067a8b8ce6e2e14999cd879329648d9de3b46a24323f
@@ -309,37 +309,37 @@
       sha256:a76c3a909d13359ed7595df585a9092d7e05b564a139abe9fe611bbfefaff84f
 | CronJob :
     ./types/io.k8s.api.batch.v1.CronJob.dhall
-      sha256:4410441febb3b457ce18c7f1498a724937a9662ca259d67d425e8fb883eedc35
+      sha256:b1de8f0fb1cb71310062793846bc1c5c2ba3c651f95a85fc099d35f06510c17c
 | CronJobList :
     ./types/io.k8s.api.batch.v1.CronJobList.dhall
-      sha256:17d558838367764ec463f5a71aa619e3c5da1540887fc6fc8074764c55d7b6c3
+      sha256:852106d751cca0a558bc69e350d8649cbde7f764cb704b82795b9dc5e22d59e5
 | CronJobSpec :
     ./types/io.k8s.api.batch.v1.CronJobSpec.dhall
-      sha256:abcae1d07d8d890d0441f39068419b10bd956e7c0bd3409d370fbf2991ca21ba
+      sha256:d1f21f71fb026e4723b7a5484fd6779b6ad234e3aa1b4eb7da0942f47c7b1b93
 | CronJobStatus :
     ./types/io.k8s.api.batch.v1.CronJobStatus.dhall
       sha256:9b8e3c84d094e905de2f0b1a35ddbb36e155fd91cf8881ef2053a118f9de563e
 | Job :
     ./types/io.k8s.api.batch.v1.Job.dhall
-      sha256:ae0d9f9745daf2e036e760e75e7edc56c223200ba968e121f3f52c7ab7229571
+      sha256:3d6605217ea4c5fa47f261ff33d41923920d96027abf3fa36eb0d77a9f5ed096
 | JobCondition :
     ./types/io.k8s.api.batch.v1.JobCondition.dhall
       sha256:253ee70013b7ce83570cd49d6e14c029e6f652e7e70b1fac3b10213619d42f05
 | JobList :
     ./types/io.k8s.api.batch.v1.JobList.dhall
-      sha256:9ae4c166fb1475fdebb73870b8e5d77321419d3c6d6766eabb1b7f70bf17aa52
+      sha256:04741e0110b307500d3f839880467dfc4ef05db3b21857a99c04bac4910cef94
 | JobSpec :
     ./types/io.k8s.api.batch.v1.JobSpec.dhall
-      sha256:733150c4633a649435055e84f8ae01d150059039fc4dd3fbe1b278a21145ebd6
+      sha256:38bb48d33ad6d7caea5a060e835c1d19066010cf7efa33432133faf28d3c0ef5
 | JobStatus :
     ./types/io.k8s.api.batch.v1.JobStatus.dhall
       sha256:e4e81d8eeb147604f14e8e3e0e1cb40aa664ab38597e37fea05a75257c990493
 | JobTemplateSpec :
     ./types/io.k8s.api.batch.v1.JobTemplateSpec.dhall
-      sha256:1fcb818692353c42778046bba02c79873302107540a2eea37deb09fff29f3ce3
+      sha256:296b3e92b160828be0ced73274ccdd8ecec8e3dd81d907cf386f72afb51d37db
 | PodFailurePolicy :
     ./types/io.k8s.api.batch.v1.PodFailurePolicy.dhall
-      sha256:06e1c2d41091cd26c69fcdc435c7a536114329fa52d97bf7d6cedca449df5fa2
+      sha256:6c580418eb0faa2f0687c1594155ac9eb47a0e6dfec02d07395b85c84a02d2ed
 | PodFailurePolicyOnExitCodesRequirement :
     ./types/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement.dhall
       sha256:d4a392b0b061905e6fc0af2308194edda6e41292a38b78516b04f2a656a55268
@@ -348,7 +348,7 @@
       sha256:43b53130399326f040043a4d653487a35df9c35342e94f97ece4dc13e66667cf
 | PodFailurePolicyRule :
     ./types/io.k8s.api.batch.v1.PodFailurePolicyRule.dhall
-      sha256:70e2c37a714711506e1abb32a0a4d49d89998ae0f66bd59fc4b62b64faad421c
+      sha256:e72ba8e8401635ead7a9cd4847f034500493c1dec35f1e0ccad2998c336cade8
 | UncountedTerminatedPods :
     ./types/io.k8s.api.batch.v1.UncountedTerminatedPods.dhall
       sha256:3912761a94b260f7643ce02f72fa247a79d9a2c6a575749cc43641eb2d8ef764

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In the following example, we:
 
 let kubernetes =
       https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall
-        sha256:705f7bd1c157c5544143ab5917bdc3972fe941300ce4189a8ea89e6ddd9c1875
+        sha256:263ee915ef545f2d771fdcd5cfa4fbb7f62772a861b5c197f998e5b71219112c
 
 let deployment =
       kubernetes.Deployment::{
@@ -151,7 +151,7 @@ let map = Prelude.List.map
 
 let kubernetes =
       https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/master/package.dhall
-        sha256:705f7bd1c157c5544143ab5917bdc3972fe941300ce4189a8ea89e6ddd9c1875
+        sha256:263ee915ef545f2d771fdcd5cfa4fbb7f62772a861b5c197f998e5b71219112c
 
 let Service = { name : Text, host : Text, version : Text }
 

--- a/docs/README.md.dhall
+++ b/docs/README.md.dhall
@@ -142,6 +142,43 @@ this:
 dhall-to-yaml --documents --file ./resources.dhall
 ```
 
+#### Can I use my existing charts as a starting point?
+
+You can turn any YAML document into Dhall code with `yaml-to-dhall`.
+However, you need a clean YAML file without Helm's templating logic.
+You can execute the templating logic locally with `helm template`
+or get the installed manifest with `helm get manifest`.
+
+Once you have a clean YAML file, you can convert it to Dhall like so:
+```bash
+yaml-to-dhall --file deployment.yaml --output deployment.dhall
+```
+
+However, the result will not be of type `k8s.Deployment.Type` because any optional
+properties that are missing from the YAML document will be missing from the
+Dhall code as well. In other words, this will most likely fail:
+```bash
+echo "./deployment.dhall : (./package.dhall).Deployment.Type" | dhall
+```
+
+The missing properties need to be translated to empty optionals instead.
+`yaml-to-dhall` needs to know which fields exist in the type to achieve this.
+You can specify the target type like so:
+```bash
+yaml-to-dhall '(./package.dhall).Deployment.Type' --file deployment.yaml --output deployment.dhall
+```
+
+Now the type-check above should succeed.
+However, the generated Dhall file will be very large and filled with redundant
+information. The schemas in `dhall-kubernetes` specify plenty of default values
+and we would like to use those to keep our own code short.
+We can rewrite the code with schemas like so:
+```bash
+dhall rewrite-with-schemas --schemas '(./schemas.dhall)' --inplace deployment.dhall
+```
+
+Now the Dhall code should be correct and compact.
+
 ## Projects Using `dhall-kubernetes`
 
 * [dhall-prometheus-operator][dhall-prometheus-operator]: Provides types and default records for [Prometheus Operators][prometheus-operator].

--- a/examples/aws-iam-authenticator-chart.dhall
+++ b/examples/aws-iam-authenticator-chart.dhall
@@ -1,6 +1,6 @@
 let kubernetes =
       ../package.dhall
-        sha256:705f7bd1c157c5544143ab5917bdc3972fe941300ce4189a8ea89e6ddd9c1875
+        sha256:263ee915ef545f2d771fdcd5cfa4fbb7f62772a861b5c197f998e5b71219112c
 
 let release = "wintering-rodent"
 

--- a/examples/deployment.dhall
+++ b/examples/deployment.dhall
@@ -4,7 +4,7 @@ let Prelude =
 
 let kubernetes =
       ../package.dhall
-        sha256:705f7bd1c157c5544143ab5917bdc3972fe941300ce4189a8ea89e6ddd9c1875
+        sha256:263ee915ef545f2d771fdcd5cfa4fbb7f62772a861b5c197f998e5b71219112c
 
 let deployment =
       kubernetes.Deployment::{

--- a/examples/deploymentSimple.dhall
+++ b/examples/deploymentSimple.dhall
@@ -1,6 +1,6 @@
 let kubernetes =
       ../package.dhall
-        sha256:705f7bd1c157c5544143ab5917bdc3972fe941300ce4189a8ea89e6ddd9c1875
+        sha256:263ee915ef545f2d771fdcd5cfa4fbb7f62772a861b5c197f998e5b71219112c
 
 let deployment =
       kubernetes.Deployment::{

--- a/examples/ingress.dhall
+++ b/examples/ingress.dhall
@@ -6,7 +6,7 @@ let map = Prelude.List.map
 
 let kubernetes =
       ../package.dhall
-        sha256:705f7bd1c157c5544143ab5917bdc3972fe941300ce4189a8ea89e6ddd9c1875
+        sha256:263ee915ef545f2d771fdcd5cfa4fbb7f62772a861b5c197f998e5b71219112c
 
 let Service = { name : Text, host : Text, version : Text }
 

--- a/examples/service.dhall
+++ b/examples/service.dhall
@@ -4,7 +4,7 @@ let Prelude =
 
 let kubernetes =
       ../package.dhall
-        sha256:705f7bd1c157c5544143ab5917bdc3972fe941300ce4189a8ea89e6ddd9c1875
+        sha256:263ee915ef545f2d771fdcd5cfa4fbb7f62772a861b5c197f998e5b71219112c
 
 let spec =
       { selector = Some (toMap { app = "nginx" })

--- a/nix/dhall-haskell.json
+++ b/nix/dhall-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "517ad02ca3c666dcf4c7abaf3a3b3d7665fdb206",
-  "date": "2022-02-25T10:46:34-08:00",
-  "path": "/nix/store/30d5y1i97vjxvr3pcjbfj30yyml191l8-dhall-haskell-517ad02",
-  "sha256": "13cwrwbkggq9hkhx2m7vrrj5kqxpf0kjxqmga8mm1ml06qq6ix84",
+  "rev": "1b5e02e01edab0c12908c89e84d7ccc83fe25d45",
+  "date": "2023-12-28T20:45:21+01:00",
+  "path": "/nix/store/fsq6x8wff83b90ljalylkvkjnabcqza7-dhall-haskell",
+  "sha256": "1w2jpkji6km1nxr1kf3j8gx6mxfa98hv3frvx8qy4qb2vl2j0534",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,

--- a/nix/kubernetes/1.12.txt
+++ b/nix/kubernetes/1.12.txt
@@ -1,1 +1,1 @@
-18kixk3i9c2vgl5yrnvi7ybchskyvfpzs9cgc8jk9w921ryvwavg
+0cggl8v525qyxihfp28dij2rqw9im2ng1cz88p3ncw81wvgc7ny3

--- a/nix/kubernetes/1.13.txt
+++ b/nix/kubernetes/1.13.txt
@@ -1,1 +1,1 @@
-0bp716qd67dc96ibwxjn03njq7g4p0ix82dnm8a264l15rzj8v01
+1rl5n47p4ir8h8ndjkhysw1awj2p414kgcffpgrr2c6br4k9j90g

--- a/nix/kubernetes/1.14.txt
+++ b/nix/kubernetes/1.14.txt
@@ -1,1 +1,1 @@
-102qc71dlqpkslj30rhk71m7val2wxlpr8byvkjyk7l1mq0f7k3w
+1kx7ycdb2x6yly4l28g1v38psfr38a9pmrhh0mg1piz67w5yjsd1

--- a/nix/kubernetes/1.15.txt
+++ b/nix/kubernetes/1.15.txt
@@ -1,1 +1,1 @@
-1xi676jql0akwxwlh4bz95zqz042xzaigz1dqf64dhqz0dvrd395
+06d5s892jm2isrhyya6h7l6qla8h6q0sh6mqlpq05lhpgyg4p9l1

--- a/nix/kubernetes/1.16.txt
+++ b/nix/kubernetes/1.16.txt
@@ -1,1 +1,1 @@
-0qi6gp6jd5za8j5p5yv6fs784r5nglz14xcrkmij3hy86azk7qnl
+05llvw5hn5pfr71sz9zyw6398aj15dm89jjs47h96zmbbkhh1zw6

--- a/nix/kubernetes/1.17.txt
+++ b/nix/kubernetes/1.17.txt
@@ -1,1 +1,1 @@
-0qw75qr2rm7x9pf2b8dg8p5lyl7xhvj7ww8s5nvf6gx6vswkp4rs
+0y4m0gns65z9n0ybac7dk3dmhyxdzn7kc0xa1mzc1a910cbxgihw

--- a/nix/kubernetes/1.18.txt
+++ b/nix/kubernetes/1.18.txt
@@ -1,1 +1,1 @@
-140wz5wxz61pc8wm0ggjx9g712i1zpjic1zn6wffa18r10pmq36s
+1vpzh2fkfa1wzgv1akz3d4dxwvfax45nll0h2nkj8fl6snq1v548

--- a/nix/kubernetes/1.19.txt
+++ b/nix/kubernetes/1.19.txt
@@ -1,1 +1,1 @@
-1l1qc3xvz4c2bjhm1x3khn7cifw4vi3icy2i8v7dbdgaz1s7fdn4
+0a4xn67iml7msgl06fmxrajhbv8ssvca4m7nhh9s9ydvakfvhs3f

--- a/nix/kubernetes/1.20.txt
+++ b/nix/kubernetes/1.20.txt
@@ -1,1 +1,1 @@
-0074pmrc14rcbilfslfr1hxqpncicp1i6j3fm0b33jicw247g8v2
+0l9p73nfpnwyr0i41qr4gl9wzflqmbi5flmh8j9hqsxknaz4rzkh

--- a/nix/kubernetes/1.24.txt
+++ b/nix/kubernetes/1.24.txt
@@ -1,1 +1,1 @@
-0l11yvwc45dxrq8pq5h4zr749zfw9z1fh8bgmbrj87xff4gmlkj7
+06y7xmll7yy3psa2m0y40mj0bwypa3mpz5ahnm0ymbdip2hycjaj

--- a/nix/kubernetes/1.25.txt
+++ b/nix/kubernetes/1.25.txt
@@ -1,1 +1,1 @@
-1010lakix68fi8llf67fhp716yirn509giak5pb9cqpc5n8g59n7
+0i4pq7q4nl1cv52bmin153i52vb046cd350xpw8jhqfqmmv1274m

--- a/nix/kubernetes/1.26.txt
+++ b/nix/kubernetes/1.26.txt
@@ -1,1 +1,1 @@
-0wcdn28ahsb0y2zcn2q9q3jw7hf124a6gbifszghn9ir0drza0rb
+15zwpy1pb3gsx5bp2q3rzb59m9b16fjgd6jm30f70qs04c73mqax


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-kubernetes/issues/191

… by no longer mistakenly preferring `v1` or `v2beta{1,2}` over all other versions